### PR TITLE
enhance gcc/mingw 32/64 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,15 @@
+cmake_minimum_required(VERSION 3.20)
+
 file(GLOB_RECURSE PSYCROSS_SRCS_C
-	"*.c"
+	"*.c" "*.C"
 )
 
 file(GLOB_RECURSE PSYCROSS_SRCS_CPP
 	"*.cpp"
 )
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-narrowing")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing")
 
 set_source_files_properties( ${PSYCROSS_SRCS_C} PROPERTIES LANGUAGE C)
 set_source_files_properties( ${PSYCROSS_SRCS_CPP} PROPERTIES LANGUAGE CXX)
@@ -18,6 +23,6 @@ find_package(SDL2 REQUIRED)
 target_link_libraries(psycross_static ${SDL2_LIBRARIES})
 target_include_directories(psycross_static PRIVATE ${SDL2_INCLUDE_DIRS})
 
-find_package(OPENAL REQUIRED)
+find_package(OpenAL REQUIRED)
 target_link_libraries(psycross_static OpenAL)
 target_include_directories(psycross_static PRIVATE ${OpenAL_BINARY_DIR} ${OpenAL_SOURCE_DIR}/include)

--- a/include/psx/kernel.h
+++ b/include/psx/kernel.h
@@ -109,7 +109,7 @@ struct EvCB {
 };
 
 //#if !defined(D3D9)
-#if 0///@FIXME Really not defined D3D9 :/
+#if __GNUC__///@FIXME Really not defined D3D9 :/
 struct EXEC {                   
         unsigned int pc0;      
         unsigned int gp0;      

--- a/src/PsyX_main.cpp
+++ b/src/PsyX_main.cpp
@@ -25,6 +25,7 @@
 #include "PsyX/PsyX_render.h"
 
 #ifdef _WIN32
+#include <windows.h>
 #include <pla.h>
 #endif // _WIN32
 
@@ -269,7 +270,8 @@ static void PsyX_Sys_InitialiseInput()
 }
 
 #ifdef __GNUC__
-#define _stricmp(s1, s2) strcasecmp(s1, s2)
+// should be strcasecmp, but this one never existed in C's std, and all the usage-cases don't seem to fail on Linux/Mingw.
+#define _stricmp(s1, s2) strcmp(s1, s2)
 #endif
 
 // Keyboard mapping lookup

--- a/src/psx/LIBGPU.C
+++ b/src/psx/LIBGPU.C
@@ -550,7 +550,7 @@ void CatPrim(void* p0, void* p1)
 	catPrim(p0, p1);
 }
 
-u_short LoadTPage(u_int* pix, int tp, int abr, int x, int y, int w, int h)
+u_short LoadTPage(u_long* pix, int tp, int abr, int x, int y, int w, int h)
 {
 	RECT16 imageArea;
 	imageArea.x = x;

--- a/src/psx/LIBGTE.C
+++ b/src/psx/LIBGTE.C
@@ -134,7 +134,7 @@ void RotTransSV(SVECTOR* v0, SVECTOR* v1, long* flag)
 	gte_stflg(flag);
 }
 
-int RotTransPers(SVECTOR* v0, int* sxy, long* p, long* flag)
+int RotTransPers(SVECTOR* v0, long* sxy, long* p, long* flag)
 {
 	int sz;
 	gte_RotTransPers(v0, sxy, p, flag, &sz);


### PR DESCRIPTION
Allows building in GCC (i686-linux-gnu, x86_64-linux-gnu), mingw32, and mingw-w64.

I tested and `3.20` is really the minimum here.

Currently, in use at https://github.com/CTR-tools/CTR-ModSDK/blob/c2e7146ed73eb2892166c45df7c9bcaf5e89ac93/rebuild_PC/PsyCross.nix

Please — test it if it still compiles in your usual working environment.

PS: Thanks for this awesome project!

A curiosity I found: PsyCross is compatible with Mesa3D's Zink, one can play CTR in a Vulkan-only environment.