### PR TITLE
macOS Apple Silicon arm64 + Vulkan/MoltenVK backend

### DIFF
--- a/include/PsyX/PsyX_render.h
+++ b/include/PsyX/PsyX_render.h
@@ -5,8 +5,13 @@
 
 /*
  * Platform specific emulator setup
+ *
+ * RENDERER_VK can be defined externally (via build system) to opt into
+ * the Vulkan/MoltenVK backend instead of the default OpenGL one.
  */
-#if (defined(_WIN32) || defined(__APPLE__) || defined(__linux__)) && !defined(__ANDROID__) && !defined(__EMSCRIPTEN__) && !defined(__RPI__)
+#if defined(RENDERER_VK)
+    /* Vulkan backend selected — keep RENDERER_OGL/OGLES undefined */
+#elif (defined(_WIN32) || defined(__APPLE__) || defined(__linux__)) && !defined(__ANDROID__) && !defined(__EMSCRIPTEN__) && !defined(__RPI__)
 #   define RENDERER_OGL
 #   define USE_GLAD
 #elif defined(__RPI__)
@@ -26,6 +31,14 @@
 #   define USE_OPENGL 0
 #endif
 
+#if defined(RENDERER_VK)
+#   define USE_VULKAN 1
+#else
+#   ifndef USE_VULKAN
+#   define USE_VULKAN 0
+#   endif
+#endif
+
 #if OGLES_VERSION == 2
 #   define ES2_SHADERS
 #elif OGLES_VERSION == 3
@@ -35,22 +48,15 @@
  /*
   * OpenGL
   */
-
 #if defined (RENDERER_OGL)
 
 #   define GL_GLEXT_PROTOTYPES
-
-#if defined(USE_GLAD)
 #   include "common/glad.h"
-#endif
 
 #elif defined (RENDERER_OGLES)
 
 #   define GL_GLEXT_PROTOTYPES
 
-#if defined(USE_GLAD)
-#   include "common/glad.h"
-#else
 #   ifdef __EMSCRIPTEN__
 #      include <GL/gl.h>
 #   else
@@ -61,7 +67,6 @@
 #          include <GLES3/gl3.h>
 #      endif
 #   endif
-#endif
 
 #   include <EGL/egl.h>
 
@@ -72,6 +77,9 @@
 #   define TEXTURE_FORMAT GL_UNSIGNED_SHORT_1_5_5_5_REV
 #elif defined(RENDERER_OGLES)
 #   define TEXTURE_FORMAT GL_UNSIGNED_SHORT_5_5_5_1
+#elif defined(RENDERER_VK)
+/* Vulkan equivalent: VK_FORMAT_A1R5G5B5_UNORM_PACK16. Symbolic constant
+ * resolved in the Vulkan backend; nothing to define here for the public header. */
 #endif
 
 #include "psx/types.h"
@@ -105,6 +113,8 @@
 #elif defined(RENDERER_OGLES)
 #	define VRAM_FORMAT            GL_LUMINANCE_ALPHA
 #	define VRAM_INTERNAL_FORMAT   GL_LUMINANCE_ALPHA
+#elif defined(RENDERER_VK)
+/* Vulkan: VRAM is emulated as a R32G32_SFLOAT image (analogous to GL_RG32F) */
 #endif
 
 #define VRAM_WIDTH		(1024)
@@ -163,8 +173,13 @@ typedef enum
 #if defined(RENDERER_OGLES) || defined(RENDERER_OGL)
 typedef uint TextureID;
 typedef uint ShaderID;
+#elif defined(RENDERER_VK)
+/* Vulkan: opaque uint32_t handles into internal Vulkan resource tables.
+ * Backend manages VkImage/VkImageView/VkSampler/VkPipeline creation. */
+typedef uint TextureID;
+typedef uint ShaderID;
 #else
-#error
+#error "No renderer backend selected"
 #endif
 
 #if defined(_LANGUAGE_C_PLUS_PLUS)||defined(__cplusplus)||defined(c_plusplus)

--- a/include/PsyX/common/pgxp_defs.h
+++ b/include/PsyX/common/pgxp_defs.h
@@ -41,6 +41,9 @@ extern "C" {
 extern PGXPVector3D g_FP_SXYZ0; // direct access PGXP without table lookup
 extern PGXPVector3D g_FP_SXYZ1;
 extern PGXPVector3D g_FP_SXYZ2;
+extern ushort g_FP_SXYZ0Index;
+extern ushort g_FP_SXYZ1Index;
+extern ushort g_FP_SXYZ2Index;
 
 /* clears PGXP vertex buffer */
 void	PGXP_ClearCache();
@@ -53,9 +56,12 @@ void	PGXP_SetZOffsetScale(float offset, float scale);
 
 /* searches for vertex with given lookup value */
 int		PGXP_GetCacheData(PGXPVData* out, uint lookup, ushort indexhint /* = 0xFFFF */);
+int		PGXP_GetCacheDataExact(PGXPVData* out, uint lookup, ushort indexhint);
 
 /* used by primitive setup */
 ushort	PGXP_GetIndex(int checkTransform);
+void	PGXP_RecordAddressIndex(const void* address, ushort index);
+ushort	PGXP_GetAddressIndex(const void* address);
 
 #if defined(_LANGUAGE_C_PLUS_PLUS)||defined(__cplusplus)||defined(c_plusplus)
 }

--- a/include/psx/inline_c.h
+++ b/include/psx/inline_c.h
@@ -104,10 +104,10 @@ extern int doCOP2(int op);
 		MTC2(*(uint*)((char*)(r2)), 22); \
 		MTC2(*(uint*)((char*)(r2)), 6); }
 
-// mtc2 12, lwc2 1
+// mtc2 0, lwc2 1
 #define gte_ldlv0( r0 ) \
-	{	MTC2((*(ushort*)((char*)(r0)+4) << 16) | *(ushort*)((char*)(r0)), 12);\
-		MTC2(*(ushort*)((char*)(r0)+8), 1); }
+	{	MTC2((*(ushort*)((char*)(r0)+4) << 16) | *(ushort*)((char*)(r0)));\
+		MTC2(*(ushort*)((char*)(r0)+8) << 16); }
 
 // mtc2 8
 #define gte_lddp( r0 )	\

--- a/include/psx/inline_c.h
+++ b/include/psx/inline_c.h
@@ -26,6 +26,13 @@ extern int CFC2_S(int reg);
 /* performs cop2 opcode */
 extern int doCOP2(int op);
 
+#if USE_PGXP
+extern unsigned short g_FP_SXYZ0Index;
+extern unsigned short g_FP_SXYZ1Index;
+extern unsigned short g_FP_SXYZ2Index;
+extern void PGXP_RecordAddressIndex(const void* address, unsigned short index);
+#endif
+
 #if defined(_LANGUAGE_C_PLUS_PLUS)||defined(__cplusplus)||defined(c_plusplus)
 }
 #endif
@@ -547,24 +554,30 @@ extern int doCOP2(int op);
 
 // swc2 14
 #define gte_stsxy( r0 ) \
-	{*(uint*)((char*)(r0)) = *(uint*)&g_FP_SXYZ2.x;}
+	{	*(uint*)((char*)(r0)) = *(uint*)&g_FP_SXYZ2.x; \
+		PGXP_RecordAddressIndex((const void*)(r0), g_FP_SXYZ2Index);}
 
 // mfc2 12-14
 #define gte_stsxy3( r0, r1, r2 )	\
 	{	*(uint*)((char*)(r0)) = *(uint*)&g_FP_SXYZ0.x;\
 		*(uint*)((char*)(r1)) = *(uint*)&g_FP_SXYZ1.x;\
-		*(uint*)((char*)(r2)) = *(uint*)&g_FP_SXYZ2.x;}
+		*(uint*)((char*)(r2)) = *(uint*)&g_FP_SXYZ2.x;\
+		PGXP_RecordAddressIndex((const void*)(r0), g_FP_SXYZ0Index);\
+		PGXP_RecordAddressIndex((const void*)(r1), g_FP_SXYZ1Index);\
+		PGXP_RecordAddressIndex((const void*)(r2), g_FP_SXYZ2Index);}
 
 // swc2 14
 #define gte_stsxy2( r0 ) gte_stsxy(r0)
 
 // swc2 13
 #define gte_stsxy1( r0 ) \
-	{	*(uint*)((char*)(r0)) = *(uint*)&g_FP_SXYZ1.x;}
+	{	*(uint*)((char*)(r0)) = *(uint*)&g_FP_SXYZ1.x;\
+		PGXP_RecordAddressIndex((const void*)(r0), g_FP_SXYZ1Index);}
 
 // swc2 12
 #define gte_stsxy0( r0 ) \
-	{	*(uint*)((char*)(r0)) = *(uint*)&g_FP_SXYZ0.x;}
+	{	*(uint*)((char*)(r0)) = *(uint*)&g_FP_SXYZ0.x;\
+		PGXP_RecordAddressIndex((const void*)(r0), g_FP_SXYZ0Index);}
 
 #else
 

--- a/include/psx/libgpu.h
+++ b/include/psx/libgpu.h
@@ -329,14 +329,14 @@ typedef struct _RECT16 {
 
 #if USE_EXTENDED_PRIM_POINTERS
 
-#if defined(_M_X64) || defined(__amd64__)
+#if defined(_M_X64) || defined(__amd64__) || defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64)
 
 #define DECLARE_P_ADDR \
 		uintptr_t addr; \
 		uint len : 16; \
 		uint pgxp_index : 16;
 
-#define P_LEN		3		// 3 longs
+#define P_LEN		3		// 3 longs (addr is 8 bytes on 64-bit + 4 bytes len/pgxp_index)
 
 #else
 
@@ -347,7 +347,7 @@ typedef struct _RECT16 {
 
 #define P_LEN		2		// 2 longs
 
-#endif // _M_X64 || __amd64__
+#endif // 64-bit detection
 
 #define DECLARE_P_ADDR_PTAG DECLARE_P_ADDR
 

--- a/include/psx/libgte.h
+++ b/include/psx/libgte.h
@@ -48,7 +48,7 @@ SVECTOR *ApplyMatrixSV(MATRIX *m, SVECTOR *v0, SVECTOR *v1);
 VECTOR *ApplyMatrixLV(MATRIX *m, VECTOR *v0, VECTOR *v1);
 extern void RotTrans(SVECTOR* v0, VECTOR* v1, long* flag);
 extern void RotTransSV(SVECTOR* v0, SVECTOR* v1, long* flag);
-extern int RotTransPers(SVECTOR* v0, int* sxy, long* p, long* flag);
+extern int RotTransPers(SVECTOR* v0, long* sxy, long* p, long* flag);
 extern int RotTransPers3(SVECTOR* v0, SVECTOR* v1, SVECTOR* v2, long* sxy0, long* sxy1, long* sxy2, long* p, long* flag);
 extern int RotTransPers4(SVECTOR* v0, SVECTOR* v1, SVECTOR* v2, SVECTOR* v3, long* sxy0, long* sxy1, long* sxy2, long* sxy3, long* p, long* flag);
 extern void NormalColor(SVECTOR* v0, CVECTOR* v1);

--- a/include/psx/types.h
+++ b/include/psx/types.h
@@ -4,6 +4,26 @@
 #include <stdint.h>
 #include <stddef.h>
 
+/*
+ * Pre-empt macOS/BSD <sys/types.h> from declaring u_long as `unsigned long`
+ * (which is 64-bit on LP64). PSX code expects u_long to be 32-bit, so we
+ * mark the system's guard and define u_long ourselves below.
+ */
+#if defined(__APPLE__) && (defined(__LP64__) || defined(_LP64))
+#  ifndef _U_LONG
+#    define _U_LONG
+#  endif
+#  ifndef _U_INT
+#    define _U_INT
+#  endif
+#  ifndef _U_CHAR
+#    define _U_CHAR
+#  endif
+#  ifndef _U_SHORT
+#    define _U_SHORT
+#  endif
+#endif
+
 #if !defined(__APPLE__)
 /* major part of a device */
 #define	major(x)	((int)(((unsigned)(x)>>8)&0377))
@@ -30,7 +50,17 @@ typedef	unsigned int	u_int;
 #endif
 #ifndef _ULONG_T
 #define _ULONG_T
+/*
+ * The original PSX SDK treats `u_long` as a 32-bit type. On LP64 platforms
+ * (macOS arm64/x64, Linux x64) `unsigned long` is 64-bit, which breaks the
+ * PSX-style packing/casting throughout the codebase. Map it to uint32_t on
+ * those targets to preserve binary layout and call-site compatibility.
+ */
+#if defined(__LP64__) || defined(_LP64)
+typedef	uint32_t	u_long;
+#else
 typedef	unsigned long	u_long;
+#endif
 #endif
 #ifndef _SYSIII_USHORT
 #define _SYSIII_USHORT
@@ -43,10 +73,16 @@ typedef	unsigned int	uint;		/* sys V compat */
 #endif
 #ifndef _SYSV_ULONG
 #define _SYSV_ULONG
+#if defined(__LP64__) || defined(_LP64)
+typedef	uint32_t	ulong;		/* sys V compat */
+#else
 typedef	unsigned long	ulong;		/* sys V compat */
+#endif
 #endif
 #endif /* ! __psx__ */
 
+#ifndef NBBY
 #define	NBBY	8
+#endif
 
 #endif

--- a/src/PsyX_main.cpp
+++ b/src/PsyX_main.cpp
@@ -146,8 +146,35 @@ int PsyX_Sys_SetVMode(int mode)
 	return old;
 }
 
+// Drives the vsync_callback + vblank counter from the calling thread.
+// Originally this was done from a separate `intrThreadMain` thread, but
+// firing PSX-VBlank callbacks asynchronously while the main thread was in
+// the middle of building the OT / running game logic raced badly on
+// arm64 (LP64 + weaker memory ordering than x86), producing intermittently
+// missing geometry. Doing it inline here keeps everything single-threaded.
+static void PsyX_PollVBlankFromMainThread(void)
+{
+	const double timestep = g_vmode == MODE_NTSC ? FIXED_TIME_STEP_NTSC : FIXED_TIME_STEP_PAL;
+
+	// Catch up: fire one callback per missed timestep
+	while (1)
+	{
+		const double vblDelta = Util_GetHPCTime(&g_vblTimer, 0);
+		if (vblDelta < timestep)
+			break;
+
+		if (vsync_callback)
+			vsync_callback();
+
+		g_psxSysCounters[PsxCounter_VBLANK]++;
+		Util_GetHPCTime(&g_vblTimer, 1);
+	}
+}
+
 int PsyX_Sys_GetVBlankCount()
 {
+	PsyX_PollVBlankFromMainThread();
+
 	if (g_skipSwapInterval)
 	{
 		// extra speedup.
@@ -155,62 +182,30 @@ int PsyX_Sys_GetVBlankCount()
 		g_psxSysCounters[PsxCounter_VBLANK] += 1;
 		g_frameSkip++;
 	}
-	
+
 	return g_psxSysCounters[PsxCounter_VBLANK];
 }
 
+// Kept as a no-op stub so any external callers / port code still link.
+// The real logic now lives in PsyX_PollVBlankFromMainThread() and runs
+// on the main thread via PsyX_Sys_GetVBlankCount().
 int intrThreadMain(void* data)
 {
-	Util_InitHPCTimer(&g_vblTimer);
-
-	while (!g_stopIntrThread)
-	{
-		// step counters
-		{
-			const double timestep = g_vmode == MODE_NTSC ? FIXED_TIME_STEP_NTSC : FIXED_TIME_STEP_PAL;
-			const double vblDelta = Util_GetHPCTime(&g_vblTimer, 0);
-
-			if (vblDelta > timestep)
-			{
-				SDL_LockMutex(g_intrMutex);
-				
-				if (vsync_callback)
-					vsync_callback();
-				
-				SDL_UnlockMutex(g_intrMutex);
-				
-				// do vblank events
-				g_psxSysCounters[PsxCounter_VBLANK]++;
-			
-				Util_GetHPCTime(&g_vblTimer, 1);
-			}
-			
-		}
-	}
-
+	(void)data;
 	return 0;
 }
 
 static int PsyX_Sys_InitialiseCore()
 {
-#ifdef __EMSCRIPTEN__
+	// Initialise the timer on whichever thread will be polling vblank
+	// (always the main thread now).
 	Util_InitHPCTimer(&g_vblTimer);
-#else
 
-	g_intrThread = SDL_CreateThread(intrThreadMain, "psyX_intr", NULL);
-
-	if (NULL == g_intrThread)
-	{
-		eprinterr("SDL_CreateThread failed: %s\n", SDL_GetError());
-		return 0;
-	}
-	
-	g_intrMutex = SDL_CreateMutex();
-	if (NULL == g_intrMutex)
-	{
-		eprinterr("SDL_CreateMutex failed: %s\n", SDL_GetError());
-		return 0;
-	}
+#ifndef __EMSCRIPTEN__
+	// We no longer spawn `psyX_intr`. The mutex is left null because no
+	// other thread takes it; any legacy locking sites are guarded.
+	g_intrThread = NULL;
+	g_intrMutex = NULL;
 #endif
 	return 1;
 }

--- a/src/audio/PsyX_SPUAL.cpp
+++ b/src/audio/PsyX_SPUAL.cpp
@@ -10,10 +10,7 @@
 #include <AL/al.h>
 #include <AL/alc.h>
 #include <AL/alext.h>
-
-#ifndef __EMSCRIPTEN__
 #include <AL/efx.h>
-#endif
 
 // TODO: implement XA, implement ADSR
 
@@ -95,8 +92,6 @@ ALuint		g_nAlReverbEffect = 0;
 int			g_enableSPUReverb = 0;
 int			g_ALEffectsSupported = 0;
 
-#ifndef __EMSCRIPTEN__
-
 LPALGENEFFECTS alGenEffects = NULL;
 LPALDELETEEFFECTS alDeleteEffects = NULL;
 LPALEFFECTI alEffecti = NULL;
@@ -105,12 +100,10 @@ LPALGENAUXILIARYEFFECTSLOTS alGenAuxiliaryEffectSlots = NULL;
 LPALDELETEAUXILIARYEFFECTSLOTS alDeleteAuxiliaryEffectSlots = NULL;
 LPALAUXILIARYEFFECTSLOTI alAuxiliaryEffectSloti = NULL;
 
-#endif // __EMSCRIPTEN__
-
 static void InitOpenAlEffects()
 {
 	g_ALEffectsSupported = 0;
-#ifndef __EMSCRIPTEN__
+
 	if (!alcIsExtensionPresent(g_ALCdevice, ALC_EXT_EFX_NAME))
 	{
 		eprintf("PSX SPU effects are NOT supported!\n");
@@ -152,7 +145,6 @@ static void InitOpenAlEffects()
 	eprintf("PSX SPU effects are supported and initialized\n");
 
 	alAuxiliaryEffectSloti(g_ALEffectSlots[g_currEffectSlotIdx], AL_EFFECTSLOT_EFFECT, g_nAlReverbEffect);
-#endif // __EMSCRIPTEN__
 }
 
 int PsyX_SPUAL_InitSound()
@@ -173,9 +165,7 @@ int PsyX_SPUAL_InitSound()
 	static int al_context_params[] =
 	{
 		ALC_FREQUENCY, 44100,
-#ifndef __EMSCRIPTEN__
 		ALC_MAX_AUXILIARY_SENDS, 2,
-#endif
 		0
 	};
 
@@ -246,9 +236,8 @@ int PsyX_SPUAL_InitSound()
 
 		alGenSources(1, &voice->alSource);
 		alGenBuffers(1, &voice->alBuffer);
-#ifdef AL_SOFT_source_resampler
+
 		alSourcei(voice->alSource, AL_SOURCE_RESAMPLER_SOFT, 2);	// Use cubic resampler
-#endif
 		alSourcei(voice->alSource, AL_SOURCE_RELATIVE, AL_TRUE);
 	}
 
@@ -334,7 +323,7 @@ u_int PsyX_SPUAL_Write(u_char* addr, u_int size)
 
 	if (wptr_ofs + size > SPU_REALMEMSIZE)
 	{
-		eprintf("SPU WARNING: SpuWrite exceeded SPU_REALMEMSIZE by %d bytes!\n", wptr_ofs + size - SPU_REALMEMSIZE);
+		eprintf("SPU WARNING: SpuWrite exceeded SPU_REALMEMSIZE (%d > 512k)!\n", wptr_ofs + size);
 	}
 	assert(size > 0 && wptr_ofs + size < SPU_MEMSIZE);
 
@@ -385,7 +374,7 @@ u_int PsyX_SPUAL_Read(u_char* addr, u_int size)
 
 	if (rptr_ofs + size > SPU_REALMEMSIZE)
 	{
-		eprintf("SPU WARNING: SpuRead exceeded SPU_REALMEMSIZE by %d bytes!\n", rptr_ofs + size - SPU_REALMEMSIZE);
+		eprintf("SPU WARNING: SpuRead exceeded SPU_REALMEMSIZE (%d > 512k)!\n", rptr_ofs + size);
 	}
 	assert(size > 0 && rptr_ofs + size < SPU_MEMSIZE);
 
@@ -525,7 +514,7 @@ static void UpdateVoiceSample(SPUALVoice* voice)
 	loopStart = 0;
 	loopLen = 0;
 
-	count = decodeSound(s_SpuMemory.samplemem + voice->attr.addr, SPU_MEMSIZE - voice->attr.addr, waveBuffer, &loopStart, &loopLen, 1);
+	count = decodeSound(s_SpuMemory.samplemem + voice->attr.addr, SPU_REALMEMSIZE - voice->attr.addr, waveBuffer, &loopStart, &loopLen, 1);
 
 	if (count == 0)
 		return;
@@ -778,7 +767,7 @@ int PsyX_SPUAL_SetReverb(int on_off)
 
 	if (!g_spuInit)
 		return old_state;
-#ifndef __EMSCRIPTEN__
+
 	// switch if needed
 	if (g_ALEffectsSupported && old_state != g_enableSPUReverb)
 	{
@@ -793,7 +782,7 @@ int PsyX_SPUAL_SetReverb(int on_off)
 			alAuxiliaryEffectSloti(g_ALEffectSlots[1], AL_EFFECTSLOT_EFFECT, AL_EFFECT_NULL);
 		}
 	}
-#endif // __EMSCRIPTEN__
+
 	return old_state;
 }
 
@@ -823,12 +812,10 @@ u_int PsyX_SPUAL_SetReverbVoice(int on_off, u_int voice_bit)
 			continue;
 
 		voice->reverb = on_off > 0;
-#ifndef __EMSCRIPTEN__
 		if (on_off)
 			alSource3i(alSource, AL_AUXILIARY_SEND_FILTER, g_ALEffectSlots[g_currEffectSlotIdx], 0, AL_FILTER_NULL);
 		else
 			alSource3i(alSource, AL_AUXILIARY_SEND_FILTER, AL_EFFECTSLOT_NULL, 0, AL_FILTER_NULL);
-#endif // __EMSCRIPTEN__
 	}
 
 	SDL_UnlockMutex(g_SpuMutex);

--- a/src/gpu/PsyX_GPU.cpp
+++ b/src/gpu/PsyX_GPU.cpp
@@ -796,7 +796,7 @@ void DrawAllSplits()
 // forward declarations
 int ParsePrimitive(P_TAG* polyTag);
 
-void ParsePrimitivesLinkedList(u_long* p, int singlePrimitive)
+void ParsePrimitivesLinkedList(u_int* p, int singlePrimitive)
 {
 	if (!p)
 		return;

--- a/src/gpu/PsyX_GPU.cpp
+++ b/src/gpu/PsyX_GPU.cpp
@@ -44,6 +44,8 @@ struct GPUDrawSplit
 
 	int				drawPrimMode;
 
+	bool			depthEnable;
+
 	u_short			startVertex;
 	u_short			numVerts;
 
@@ -64,6 +66,7 @@ void ClearSplits()
 	g_vertexIndex = 0;
 	g_splitIndex = 0;
 	g_splits[0].texFormat = (TexFormat)0xFFFF;
+	g_splits[0].depthEnable = false;
 }
 
 template<class T>
@@ -176,40 +179,57 @@ void MakeLineArray(GrVertex* vertex, VERTTYPE* p0, VERTTYPE* p1, ushort gteidx)
 	ScreenCoordsToEmulator(vertex, 4);
 }
 
-inline void ApplyVertexPGXP(GrVertex* v, VERTTYPE* p, float ofsX, float ofsY, ushort gteidx, int lookupOfs)
-{
 #if USE_PGXP
+static const float kPGXPMinPerspectiveZ = 0.25f;
+
+inline int FindVertexPGXP(PGXPVData* vd, VERTTYPE* p, ushort gteidx, int lookupOfs)
+{
 	uint lookup = PGXP_LOOKUP_VALUE(p[0], p[1]);
+	int hasData = 0;
 
-	PGXPVData vd;
-	if (gteidx != 0xffff &&
-		g_cfg_pgxpTextureCorrection && 
-		PGXP_GetCacheData(&vd, lookup, gteidx + lookupOfs))
+	if (g_cfg_pgxpTextureCorrection)
 	{
-		v->x = vd.px;
-		v->y = vd.py;
-		v->z = vd.pz;
+		const ushort addressIndex = PGXP_GetAddressIndex(p);
+		if (addressIndex != 0xffff)
+			hasData = PGXP_GetCacheDataExact(vd, lookup, addressIndex);
 
-		// calculate offset for our perspective matrix based on supposed GTE transformed geometry offset
-		float dispW, dispH;
-		DrawEnvDimensions(dispW, dispH);
-
-		const float gteOfsX = fmodf(vd.ofx, dispW) - dispW * 0.5f;
-		const float gteOfsY = fmodf(vd.ofy, dispH) - dispH * 0.5f;
-
-		v->ofsX = (ofsX + gteOfsX) / dispW * 2.0f;
-		v->ofsY = (ofsY + gteOfsY) / dispH * 2.0f;
-		v->scr_h = vd.scr_h;
+		if (!hasData && gteidx != 0xffff)
+			hasData = PGXP_GetCacheData(vd, lookup, gteidx + lookupOfs);
 	}
-	else
-	{
-		v->scr_h = 0.0f;
-		v->z = 0.0f;
-	}
-#endif
+
+	return hasData;
 }
 
-void MakeVertexTriangle(GrVertex* vertex, VERTTYPE* p0, VERTTYPE* p1, VERTTYPE* p2, ushort gteidx)
+inline int PrimitivePGXPValid(const PGXPVData* vd, int count)
+{
+	for (int i = 0; i < count; i++) {
+		if (vd[i].scr_h <= 100.0f || vd[i].pz <= kPGXPMinPerspectiveZ)
+			return 0;
+	}
+
+	return 1;
+}
+
+inline void ApplyVertexPGXP(GrVertex* v, const PGXPVData& vd, float ofsX, float ofsY)
+{
+	v->x = vd.px;
+	v->y = vd.py;
+	v->z = vd.pz;
+
+	// calculate offset for our perspective matrix based on supposed GTE transformed geometry offset
+	float dispW, dispH;
+	DrawEnvDimensions(dispW, dispH);
+
+	const float gteOfsX = fmodf(vd.ofx, dispW) - dispW * 0.5f;
+	const float gteOfsY = fmodf(vd.ofy, dispH) - dispH * 0.5f;
+
+	v->ofsX = (ofsX + gteOfsX) / dispW * 2.0f;
+	v->ofsY = (ofsY + gteOfsY) / dispH * 2.0f;
+	v->scr_h = vd.scr_h;
+}
+#endif
+
+bool MakeVertexTriangle(GrVertex* vertex, VERTTYPE* p0, VERTTYPE* p1, VERTTYPE* p2, ushort gteidx)
 {
 	assert(p0);
 	assert(p1);
@@ -229,14 +249,27 @@ void MakeVertexTriangle(GrVertex* vertex, VERTTYPE* p0, VERTTYPE* p1, VERTTYPE* 
 	vertex[2].x = p2[0] + ofsX;
 	vertex[2].y = p2[1] + ofsY;
 
-	ApplyVertexPGXP(&vertex[0], p0, ofsX, ofsY, gteidx, -2);
-	ApplyVertexPGXP(&vertex[1], p1, ofsX, ofsY, gteidx, -1);
-	ApplyVertexPGXP(&vertex[2], p2, ofsX, ofsY, gteidx, 0);
+#if USE_PGXP
+	PGXPVData pgxp[3];
+	const int hasPGXP =
+		FindVertexPGXP(&pgxp[0], p0, gteidx, -3) &&
+		FindVertexPGXP(&pgxp[1], p1, gteidx, -2) &&
+		FindVertexPGXP(&pgxp[2], p2, gteidx, -1);
+
+	if (hasPGXP && PrimitivePGXPValid(pgxp, 3)) {
+		ApplyVertexPGXP(&vertex[0], pgxp[0], ofsX, ofsY);
+		ApplyVertexPGXP(&vertex[1], pgxp[1], ofsX, ofsY);
+		ApplyVertexPGXP(&vertex[2], pgxp[2], ofsX, ofsY);
+		ScreenCoordsToEmulator(vertex, 3);
+		return true;
+	}
+#endif
 
 	ScreenCoordsToEmulator(vertex, 3);
+	return false;
 }
 
-void MakeVertexQuad(GrVertex* vertex, VERTTYPE* p0, VERTTYPE* p1, VERTTYPE* p2, VERTTYPE* p3, ushort gteidx)
+bool MakeVertexQuad(GrVertex* vertex, VERTTYPE* p0, VERTTYPE* p1, VERTTYPE* p2, VERTTYPE* p3, ushort gteidx)
 {
 	assert(p0);
 	assert(p1);
@@ -260,12 +293,26 @@ void MakeVertexQuad(GrVertex* vertex, VERTTYPE* p0, VERTTYPE* p1, VERTTYPE* p2, 
 	vertex[3].x = p3[0] + ofsX;
 	vertex[3].y = p3[1] + ofsY;
 
-	ApplyVertexPGXP(&vertex[0], p0, ofsX, ofsY, gteidx, -3);
-	ApplyVertexPGXP(&vertex[1], p1, ofsX, ofsY, gteidx, -2);
-	ApplyVertexPGXP(&vertex[2], p2, ofsX, ofsY, gteidx, -1);
-	ApplyVertexPGXP(&vertex[3], p3, ofsX, ofsY, gteidx, 0);
+#if USE_PGXP
+	PGXPVData pgxp[4];
+	const int hasPGXP =
+		FindVertexPGXP(&pgxp[0], p0, gteidx, -4) &&
+		FindVertexPGXP(&pgxp[1], p1, gteidx, -3) &&
+		FindVertexPGXP(&pgxp[2], p2, gteidx, -1) &&
+		FindVertexPGXP(&pgxp[3], p3, gteidx, -2);
+
+	if (hasPGXP && PrimitivePGXPValid(pgxp, 4)) {
+		ApplyVertexPGXP(&vertex[0], pgxp[0], ofsX, ofsY);
+		ApplyVertexPGXP(&vertex[1], pgxp[1], ofsX, ofsY);
+		ApplyVertexPGXP(&vertex[2], pgxp[2], ofsX, ofsY);
+		ApplyVertexPGXP(&vertex[3], pgxp[3], ofsX, ofsY);
+		ScreenCoordsToEmulator(vertex, 4);
+		return true;
+	}
+#endif
 
 	ScreenCoordsToEmulator(vertex, 4);
+	return false;
 }
 
 void MakeVertexRect(GrVertex* vertex, VERTTYPE* p0, short w, short h, ushort gteidx)
@@ -677,6 +724,7 @@ static void AddSplit(bool semiTrans, bool textured)
 	BlendMode blendMode = semiTrans ? GET_TPAGE_BLEND(tpage) : BM_NONE;
 	TexFormat texFormat = GET_TPAGE_FORMAT(tpage);
 	TextureID textureId = textured ? g_vramTexture : g_whiteTexture;
+	const bool depthEnable = false;
 
 	if (textured && overrideTexture != 0)
 	{
@@ -690,6 +738,7 @@ static void AddSplit(bool semiTrans, bool textured)
 		curSplit.texFormat == texFormat &&
 		curSplit.textureId == textureId &&
 		curSplit.drawPrimMode == g_DrawPrimMode &&
+		curSplit.depthEnable == depthEnable &&
 		curSplit.drawenv.clip.x == activeDrawEnv.clip.x &&
 		curSplit.drawenv.clip.y == activeDrawEnv.clip.y &&
 		curSplit.drawenv.clip.w == activeDrawEnv.clip.w &&
@@ -713,6 +762,7 @@ static void AddSplit(bool semiTrans, bool textured)
 	split.texFormat = texFormat;
 	split.textureId = textureId;
 	split.drawPrimMode = g_DrawPrimMode;
+	split.depthEnable = depthEnable;
 	split.drawenv = activeDrawEnv;
 	split.dispenv = activeDispEnv;
 	split.debugText = currentSplitDebugText;
@@ -720,6 +770,35 @@ static void AddSplit(bool semiTrans, bool textured)
 	split.drawenv.tw.w = overrideTextureWidth;
 	split.drawenv.tw.h = overrideTextureHeight;
 
+	split.startVertex = g_vertexIndex;
+	split.numVerts = 0;
+}
+
+static void SetCurrentSplitDepth(bool depthEnable)
+{
+	GPUDrawSplit& curSplit = g_splits[g_splitIndex];
+
+	if (curSplit.depthEnable == depthEnable)
+		return;
+
+	if (curSplit.startVertex == g_vertexIndex)
+	{
+		curSplit.depthEnable = depthEnable;
+		return;
+	}
+
+	curSplit.numVerts = g_vertexIndex - curSplit.startVertex;
+
+	if (g_splitIndex + 1 >= MAX_DRAW_SPLITS)
+	{
+		eprinterr("MAX_DRAW_SPLITS reached (too many depth, blend, texture, drawEnv clip rect, dfe switches), expect rendering errors\n");
+		return;
+	}
+
+	const GPUDrawSplit previousSplit = curSplit;
+	GPUDrawSplit& split = g_splits[++g_splitIndex];
+	split = previousSplit;
+	split.depthEnable = depthEnable;
 	split.startVertex = g_vertexIndex;
 	split.numVerts = 0;
 }
@@ -741,6 +820,7 @@ void DrawSplit(const GPUDrawSplit& split)
 	GR_SetOffscreenState(&split.drawenv.clip, !drawOnScreen);
 
 	GR_SetBlendMode(split.blendMode);
+	GR_EnableDepth(split.depthEnable);
 
 	GR_DrawTriangles(split.startVertex, split.numVerts / 3);
 
@@ -1099,7 +1179,8 @@ static int ProcessFlatPoly(P_TAG* polyTag)
 		AddSplit(semiTrans, false);
 
 		GrVertex* firstVertex = &g_vertexBuffer[g_vertexIndex];
-		MakeVertexTriangle(firstVertex, &poly->x0, &poly->x1, &poly->x2, gteIndex);
+		const bool depthEnable = MakeVertexTriangle(firstVertex, &poly->x0, &poly->x1, &poly->x2, gteIndex);
+		SetCurrentSplitDepth(depthEnable);
 		MakeTexcoordTriangleZero(firstVertex, 0);
 		MakeColourTriangle(firstVertex, shadeTexOn, &poly->r0, &poly->r0, &poly->r0);
 
@@ -1121,7 +1202,8 @@ static int ProcessFlatPoly(P_TAG* polyTag)
 			AddSplit(semiTrans, true);
 
 			GrVertex* firstVertex = &g_vertexBuffer[g_vertexIndex];
-			MakeVertexTriangle(firstVertex, &poly->x0, &poly->x1, &poly->x2, gteIndex);
+			const bool depthEnable = MakeVertexTriangle(firstVertex, &poly->x0, &poly->x1, &poly->x2, gteIndex);
+			SetCurrentSplitDepth(depthEnable);
 			MakeTexcoordTriangle(firstVertex, &poly->u0, &poly->u1, &poly->u2, poly->tpage, poly->clut, GET_TPAGE_DITHER(activeDrawEnv.tpage) || activeDrawEnv.dtd);
 			MakeColourTriangle(firstVertex, shadeTexOn, &poly->r0, &poly->r0, &poly->r0);
 
@@ -1140,7 +1222,8 @@ static int ProcessFlatPoly(P_TAG* polyTag)
 		AddSplit(semiTrans, false);
 
 		GrVertex* firstVertex = &g_vertexBuffer[g_vertexIndex];
-		MakeVertexQuad(firstVertex, &poly->x0, &poly->x1, &poly->x3, &poly->x2, gteIndex);
+		const bool depthEnable = MakeVertexQuad(firstVertex, &poly->x0, &poly->x1, &poly->x3, &poly->x2, gteIndex);
+		SetCurrentSplitDepth(depthEnable);
 		MakeTexcoordQuadZero(firstVertex, 0);
 		MakeColourQuad(firstVertex, shadeTexOn, &poly->r0, &poly->r0, &poly->r0, &poly->r0);
 
@@ -1160,7 +1243,8 @@ static int ProcessFlatPoly(P_TAG* polyTag)
 		AddSplit(semiTrans, true);
 
 		GrVertex* firstVertex = &g_vertexBuffer[g_vertexIndex];
-		MakeVertexQuad(firstVertex, &poly->x0, &poly->x1, &poly->x3, &poly->x2, gteIndex);
+		const bool depthEnable = MakeVertexQuad(firstVertex, &poly->x0, &poly->x1, &poly->x3, &poly->x2, gteIndex);
+		SetCurrentSplitDepth(depthEnable);
 		MakeTexcoordQuad(firstVertex, &poly->u0, &poly->u1, &poly->u3, &poly->u2, poly->tpage, poly->clut, GET_TPAGE_DITHER(activeDrawEnv.tpage) || activeDrawEnv.dtd);
 		MakeColourQuad(firstVertex, shadeTexOn, &poly->r0, &poly->r0, &poly->r0, &poly->r0);
 
@@ -1198,7 +1282,8 @@ static int ProcessGouraudPoly(P_TAG* polyTag)
 		AddSplit(semiTrans, false);
 
 		GrVertex* firstVertex = &g_vertexBuffer[g_vertexIndex];
-		MakeVertexTriangle(firstVertex, &poly->x0, &poly->x1, &poly->x2, gteIndex);
+		const bool depthEnable = MakeVertexTriangle(firstVertex, &poly->x0, &poly->x1, &poly->x2, gteIndex);
+		SetCurrentSplitDepth(depthEnable);
 		MakeTexcoordTriangleZero(firstVertex, 1);
 		MakeColourTriangle(firstVertex, shadeTexOn, &poly->r0, &poly->r1, &poly->r2);
 
@@ -1217,7 +1302,8 @@ static int ProcessGouraudPoly(P_TAG* polyTag)
 		AddSplit(semiTrans, true);
 
 		GrVertex* firstVertex = &g_vertexBuffer[g_vertexIndex];
-		MakeVertexTriangle(firstVertex, &poly->x0, &poly->x1, &poly->x2, gteIndex);
+		const bool depthEnable = MakeVertexTriangle(firstVertex, &poly->x0, &poly->x1, &poly->x2, gteIndex);
+		SetCurrentSplitDepth(depthEnable);
 		MakeTexcoordTriangle(firstVertex, &poly->u0, &poly->u1, &poly->u2, poly->tpage, poly->clut, GET_TPAGE_DITHER(activeDrawEnv.tpage) || activeDrawEnv.dtd);
 		MakeColourTriangle(firstVertex, shadeTexOn, &poly->r0, &poly->r1, &poly->r2);
 
@@ -1235,7 +1321,8 @@ static int ProcessGouraudPoly(P_TAG* polyTag)
 		AddSplit(semiTrans, false);
 
 		GrVertex* firstVertex = &g_vertexBuffer[g_vertexIndex];
-		MakeVertexQuad(firstVertex, &poly->x0, &poly->x1, &poly->x3, &poly->x2, gteIndex);
+		const bool depthEnable = MakeVertexQuad(firstVertex, &poly->x0, &poly->x1, &poly->x3, &poly->x2, gteIndex);
+		SetCurrentSplitDepth(depthEnable);
 		MakeTexcoordQuadZero(firstVertex, 1);
 		MakeColourQuad(firstVertex, shadeTexOn, &poly->r0, &poly->r1, &poly->r3, &poly->r2);
 
@@ -1256,7 +1343,8 @@ static int ProcessGouraudPoly(P_TAG* polyTag)
 		AddSplit(semiTrans, true);
 
 		GrVertex* firstVertex = &g_vertexBuffer[g_vertexIndex];
-		MakeVertexQuad(firstVertex, &poly->x0, &poly->x1, &poly->x3, &poly->x2, gteIndex);
+		const bool depthEnable = MakeVertexQuad(firstVertex, &poly->x0, &poly->x1, &poly->x3, &poly->x2, gteIndex);
+		SetCurrentSplitDepth(depthEnable);
 		MakeTexcoordQuad(firstVertex, &poly->u0, &poly->u1, &poly->u3, &poly->u2, poly->tpage, poly->clut, GET_TPAGE_DITHER(activeDrawEnv.tpage) || activeDrawEnv.dtd);
 		MakeColourQuad(firstVertex, shadeTexOn, &poly->r0, &poly->r1, &poly->r3, &poly->r2);
 

--- a/src/gpu/PsyX_GPU.h
+++ b/src/gpu/PsyX_GPU.h
@@ -23,7 +23,7 @@ extern int g_GPUDisabledState;
 void ClearSplits();
 void DrawAllSplits();
 
-extern void ParsePrimitivesLinkedList(u_long* p, int singlePrimitive);
+extern void ParsePrimitivesLinkedList(u_int* p, int singlePrimitive);
 
 #if defined(_LANGUAGE_C_PLUS_PLUS)||defined(__cplusplus)||defined(c_plusplus)
 }

--- a/src/gte/PsyX_GTE.cpp
+++ b/src/gte/PsyX_GTE.cpp
@@ -6,6 +6,9 @@
 #include "psx/gtereg.h"
 
 #include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
 
 
@@ -283,6 +286,9 @@ int Lm_H(long long value, int sf) {
 PGXPVector3D g_FP_SXYZ0; // direct access PGXP without table lookup
 PGXPVector3D g_FP_SXYZ1;
 PGXPVector3D g_FP_SXYZ2;
+ushort g_FP_SXYZ0Index = 0xffff;
+ushort g_FP_SXYZ1Index = 0xffff;
+ushort g_FP_SXYZ2Index = 0xffff;
 
 PGXPVData g_pgxpCache[1 << sizeof(ushort)*8];
 ushort g_pgxpVertexIndex = 0;
@@ -293,9 +299,147 @@ int g_pgxpTransformed = 0;
 float g_pgxpZOffset = 0.0f;
 float g_pgxpZScale = 1.0f;
 
+struct PGXPDiagStats {
+	unsigned int emitted;
+	unsigned int getCalls;
+	unsigned int directHits;
+	unsigned int directMismatches;
+	unsigned int fallbackHits;
+	unsigned int misses;
+	unsigned int maxFallbackCycles;
+	int fallbackDeltaMin;
+	int fallbackDeltaMax;
+	long long fallbackDeltaSum;
+	unsigned int fallbackDeltaSamples;
+	unsigned int fallbackDeltaBuckets[17];
+	unsigned int fallbackDeltaOther;
+	unsigned int addressRecords;
+	unsigned int addressHits;
+	unsigned int addressMisses;
+	unsigned int nclipPositive;
+	unsigned int nclipNegative;
+	unsigned int nclipZero;
+	unsigned int rtpsCount;
+	unsigned int rtpsMac3Behind;
+	unsigned int rtpsPzBehind;
+	unsigned int rtpsPzNear;
+	float rtpsPzMin;
+	float rtpsPzMax;
+};
+
+struct PGXPAddressEntry {
+	uintptr_t address;
+	ushort index;
+	unsigned int generation;
+};
+
+#define PGXP_ADDRESS_TABLE_BITS 18
+#define PGXP_ADDRESS_TABLE_SIZE (1 << PGXP_ADDRESS_TABLE_BITS)
+#define PGXP_ADDRESS_TABLE_MASK (PGXP_ADDRESS_TABLE_SIZE - 1)
+
+PGXPAddressEntry g_pgxpAddressTable[PGXP_ADDRESS_TABLE_SIZE] = {};
+unsigned int g_pgxpAddressGeneration = 1;
+
+PGXPDiagStats g_pgxpDiagStats = {};
+unsigned int g_pgxpDiagFrame = 0;
+
+int PGXP_DiagEnabled()
+{
+	static int cached = -1;
+	if (cached < 0) {
+		const char* value = getenv("REDRIVER2_VK_DIAG");
+		cached = (value && atoi(value) != 0) ? 1 : 0;
+	}
+	return cached;
+}
+
+int PGXP_DiagInterval()
+{
+	static int cached = -1;
+	if (cached < 0) {
+		const char* value = getenv("REDRIVER2_VK_DIAG_INTERVAL");
+		cached = value ? atoi(value) : 60;
+		if (cached < 1)
+			cached = 1;
+	}
+	return cached;
+}
+
+void PGXP_DiagLogAndReset()
+{
+	if (PGXP_DiagEnabled() && g_pgxpDiagFrame % PGXP_DiagInterval() == 0) {
+		const int deltaMin = g_pgxpDiagStats.fallbackDeltaSamples ? g_pgxpDiagStats.fallbackDeltaMin : 0;
+		const int deltaMax = g_pgxpDiagStats.fallbackDeltaSamples ? g_pgxpDiagStats.fallbackDeltaMax : 0;
+		const double deltaAvg = g_pgxpDiagStats.fallbackDeltaSamples
+			? (double)g_pgxpDiagStats.fallbackDeltaSum / (double)g_pgxpDiagStats.fallbackDeltaSamples
+			: 0.0;
+
+		const float pzMin = g_pgxpDiagStats.rtpsCount ? g_pgxpDiagStats.rtpsPzMin : 0.0f;
+		const float pzMax = g_pgxpDiagStats.rtpsCount ? g_pgxpDiagStats.rtpsPzMax : 0.0f;
+
+		PsyX_Log_Info("[Psy-X] [PGXPDIAG][frame=%u] emitted=%u get=%u direct=%u mismatch=%u fallback=%u miss=%u maxFallbackCycles=%u fallbackDelta avg/min/max=%.2f/%d/%d buckets[-8..8]=%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u other=%u addr record/hit/miss=%u/%u/%u nclip +/0/-=%u/%u/%u rtps=%u mac3Behind=%u pzBehind=%u pzNear=%u pz=[%.3f %.3f]\n",
+			g_pgxpDiagFrame,
+			g_pgxpDiagStats.emitted,
+			g_pgxpDiagStats.getCalls,
+			g_pgxpDiagStats.directHits,
+			g_pgxpDiagStats.directMismatches,
+			g_pgxpDiagStats.fallbackHits,
+			g_pgxpDiagStats.misses,
+			g_pgxpDiagStats.maxFallbackCycles,
+			deltaAvg,
+			deltaMin,
+			deltaMax,
+			g_pgxpDiagStats.fallbackDeltaBuckets[0],
+			g_pgxpDiagStats.fallbackDeltaBuckets[1],
+			g_pgxpDiagStats.fallbackDeltaBuckets[2],
+			g_pgxpDiagStats.fallbackDeltaBuckets[3],
+			g_pgxpDiagStats.fallbackDeltaBuckets[4],
+			g_pgxpDiagStats.fallbackDeltaBuckets[5],
+			g_pgxpDiagStats.fallbackDeltaBuckets[6],
+			g_pgxpDiagStats.fallbackDeltaBuckets[7],
+			g_pgxpDiagStats.fallbackDeltaBuckets[8],
+			g_pgxpDiagStats.fallbackDeltaBuckets[9],
+			g_pgxpDiagStats.fallbackDeltaBuckets[10],
+			g_pgxpDiagStats.fallbackDeltaBuckets[11],
+			g_pgxpDiagStats.fallbackDeltaBuckets[12],
+			g_pgxpDiagStats.fallbackDeltaBuckets[13],
+			g_pgxpDiagStats.fallbackDeltaBuckets[14],
+			g_pgxpDiagStats.fallbackDeltaBuckets[15],
+			g_pgxpDiagStats.fallbackDeltaBuckets[16],
+			g_pgxpDiagStats.fallbackDeltaOther,
+			g_pgxpDiagStats.addressRecords,
+			g_pgxpDiagStats.addressHits,
+			g_pgxpDiagStats.addressMisses,
+			g_pgxpDiagStats.nclipPositive,
+			g_pgxpDiagStats.nclipZero,
+			g_pgxpDiagStats.nclipNegative,
+			g_pgxpDiagStats.rtpsCount,
+			g_pgxpDiagStats.rtpsMac3Behind,
+			g_pgxpDiagStats.rtpsPzBehind,
+			g_pgxpDiagStats.rtpsPzNear,
+			(double)pzMin,
+			(double)pzMax);
+	}
+
+	memset(&g_pgxpDiagStats, 0, sizeof(g_pgxpDiagStats));
+	g_pgxpDiagFrame++;
+}
+
 void PGXP_ClearCache()
 {
+	PGXP_DiagLogAndReset();
+
+	memset(g_pgxpCache, 0xFF, sizeof(g_pgxpCache));
 	g_pgxpVertexIndex = 0;
+	g_FP_SXYZ0Index = 0xffff;
+	g_FP_SXYZ1Index = 0xffff;
+	g_FP_SXYZ2Index = 0xffff;
+
+	g_pgxpAddressGeneration++;
+	if (g_pgxpAddressGeneration == 0) {
+		memset(g_pgxpAddressTable, 0, sizeof(g_pgxpAddressTable));
+		g_pgxpAddressGeneration = 1;
+	}
 }
 
 ushort PGXP_GetIndex(int checkTransform)
@@ -317,9 +461,85 @@ ushort PGXP_EmitCacheData(PGXPVData* newData)
 	if (nextIndex == 0xffff)
 		return 0xffff;
 
+	if (PGXP_DiagEnabled())
+		g_pgxpDiagStats.emitted++;
+
 	g_pgxpCache[nextIndex] = *newData;
 	g_pgxpTransformed = 1;
 	return nextIndex;
+}
+
+static unsigned int PGXP_AddressHash(uintptr_t address)
+{
+	uintptr_t value = address >> 2;
+	value ^= value >> 11;
+	value ^= value >> 23;
+	return (unsigned int)value & PGXP_ADDRESS_TABLE_MASK;
+}
+
+void PGXP_RecordAddressIndex(const void* address, ushort index)
+{
+	if (!address || index == 0xffff)
+		return;
+
+	if (PGXP_DiagEnabled())
+		g_pgxpDiagStats.addressRecords++;
+
+	const uintptr_t key = (uintptr_t)address;
+	unsigned int slot = PGXP_AddressHash(key);
+
+	for (unsigned int probe = 0; probe < PGXP_ADDRESS_TABLE_SIZE; probe++) {
+		PGXPAddressEntry* entry = &g_pgxpAddressTable[slot];
+		if (entry->generation != g_pgxpAddressGeneration || entry->address == key) {
+			entry->address = key;
+			entry->index = index;
+			entry->generation = g_pgxpAddressGeneration;
+			return;
+		}
+
+		slot = (slot + 1) & PGXP_ADDRESS_TABLE_MASK;
+	}
+}
+
+ushort PGXP_GetAddressIndex(const void* address)
+{
+	if (!address) {
+		if (PGXP_DiagEnabled())
+			g_pgxpDiagStats.addressMisses++;
+		return 0xffff;
+	}
+
+	const uintptr_t key = (uintptr_t)address;
+	unsigned int slot = PGXP_AddressHash(key);
+
+	for (unsigned int probe = 0; probe < PGXP_ADDRESS_TABLE_SIZE; probe++) {
+		PGXPAddressEntry* entry = &g_pgxpAddressTable[slot];
+		if (entry->generation != g_pgxpAddressGeneration)
+			break;
+
+		if (entry->address == key) {
+			if (PGXP_DiagEnabled())
+				g_pgxpDiagStats.addressHits++;
+			return entry->index;
+		}
+
+		slot = (slot + 1) & PGXP_ADDRESS_TABLE_MASK;
+	}
+
+	if (PGXP_DiagEnabled())
+		g_pgxpDiagStats.addressMisses++;
+
+	return 0xffff;
+}
+
+static void PGXP_ClearCacheDataOut(PGXPVData* out)
+{
+	out->px = 0.0f;
+	out->py = 0.0f;
+	out->pz = 1.0f;
+	out->scr_h = 0.0f;
+	out->ofx = 0.0f;
+	out->ofy = 0.0f;
 }
 
 void PGXP_SetZOffsetScale(float offset, float scale)
@@ -328,19 +548,56 @@ void PGXP_SetZOffsetScale(float offset, float scale)
 	g_pgxpZScale = scale;
 }
 
+int PGXP_GetCacheDataExact(PGXPVData* out, uint lookup, ushort indexhint)
+{
+	if (PGXP_DiagEnabled())
+		g_pgxpDiagStats.getCalls++;
+
+	if (indexhint != 0xFFFF && g_pgxpCache[indexhint].lookup == lookup)
+	{
+		if (PGXP_DiagEnabled())
+			g_pgxpDiagStats.directHits++;
+
+		*out = g_pgxpCache[indexhint];
+		return 1;
+	}
+
+	if (PGXP_DiagEnabled()) {
+		if (indexhint != 0xFFFF)
+			g_pgxpDiagStats.directMismatches++;
+		g_pgxpDiagStats.misses++;
+	}
+
+	PGXP_ClearCacheDataOut(out);
+	return 0;
+}
+
 // sets copy of cached vertex data to out
 int PGXP_GetCacheData(PGXPVData* out, uint lookup, ushort indexhint)
 {
+	if (PGXP_DiagEnabled())
+		g_pgxpDiagStats.getCalls++;
+
 	if (indexhint == 0xFFFF)
 	{
-		out->px = 0.0f;
-		out->py = 0.0f;
-		out->pz = 1.0f;
-		out->scr_h = 0.0f;
-		out->ofx = 0.0f;
-		out->ofx = 0.0f;
+		if (PGXP_DiagEnabled())
+			g_pgxpDiagStats.misses++;
+
+		PGXP_ClearCacheDataOut(out);
 		return 0;
 	}
+
+	if (g_pgxpCache[indexhint].lookup == lookup)
+	{
+		if (PGXP_DiagEnabled())
+			g_pgxpDiagStats.directHits++;
+
+		*out = g_pgxpCache[indexhint];
+		return 1;
+	}
+
+	if (PGXP_DiagEnabled())
+		g_pgxpDiagStats.directMismatches++;
 
 	// index hint allows us to start from specific index
 	ushort index = max(0, int(indexhint) - 8);
@@ -355,6 +612,34 @@ int PGXP_GetCacheData(PGXPVData* out, uint lookup, ushort indexhint)
 			if (i > 256)
 				PsyX_Log_Warning("PGXP_GetCacheData lookup IS inefficient: hint: %d, start: %d, found: %d, cycles: %d\n", indexhint, ushort(indexhint - 8u), index, i);
 
+			if (PGXP_DiagEnabled()) {
+				g_pgxpDiagStats.fallbackHits++;
+				if ((unsigned int)i > g_pgxpDiagStats.maxFallbackCycles)
+					g_pgxpDiagStats.maxFallbackCycles = (unsigned int)i;
+
+				int delta = (int)index - (int)indexhint;
+				if (delta > 32767)
+					delta -= 65536;
+				else if (delta < -32768)
+					delta += 65536;
+
+				if (g_pgxpDiagStats.fallbackDeltaSamples == 0) {
+					g_pgxpDiagStats.fallbackDeltaMin = delta;
+					g_pgxpDiagStats.fallbackDeltaMax = delta;
+				} else {
+					g_pgxpDiagStats.fallbackDeltaMin = min(g_pgxpDiagStats.fallbackDeltaMin, delta);
+					g_pgxpDiagStats.fallbackDeltaMax = max(g_pgxpDiagStats.fallbackDeltaMax, delta);
+				}
+
+				g_pgxpDiagStats.fallbackDeltaSum += delta;
+				g_pgxpDiagStats.fallbackDeltaSamples++;
+
+				if (delta >= -8 && delta <= 8)
+					g_pgxpDiagStats.fallbackDeltaBuckets[delta + 8]++;
+				else
+					g_pgxpDiagStats.fallbackDeltaOther++;
+			}
+
 			*out = g_pgxpCache[index];
 			return 1;
 		}
@@ -363,12 +648,10 @@ int PGXP_GetCacheData(PGXPVData* out, uint lookup, ushort indexhint)
 
 	//PsyX_Log_Warning("PGXP_GetCacheData lookup IS NOT FOUND: hint: %d\n", indexhint);
 
-	out->px = 0.0f;
-	out->py = 0.0f;
-	out->pz = 1.0f;
-	out->scr_h = 0.0f;
-	out->ofx = 0.0f;
-	out->ofx = 0.0f;
+	if (PGXP_DiagEnabled())
+		g_pgxpDiagStats.misses++;
+
+	PGXP_ClearCacheDataOut(out);
 
 	return 0;
 }
@@ -405,6 +688,8 @@ int GTE_RotTransPers(int idx, int lm)
 	
 	g_FP_SXYZ0 = g_FP_SXYZ1;
 	g_FP_SXYZ1 = g_FP_SXYZ2;
+	g_FP_SXYZ0Index = g_FP_SXYZ1Index;
+	g_FP_SXYZ1Index = g_FP_SXYZ2Index;
 
 	// do not perform perspective multiplication so it stays in object space
 	// perspective is performed exclusively in shader
@@ -412,6 +697,26 @@ int GTE_RotTransPers(int idx, int lm)
 	temp.px = fMAC1 * one_by_v * g_pgxpZScale + g_pgxpZOffset;
 	temp.py = fMAC2 * one_by_v * g_pgxpZScale + g_pgxpZOffset;
 	temp.pz = fMAC3 * one_by_v * g_pgxpZScale + g_pgxpZOffset;
+
+	if (PGXP_DiagEnabled()) {
+		if (g_pgxpDiagStats.rtpsCount == 0) {
+			g_pgxpDiagStats.rtpsPzMin = temp.pz;
+			g_pgxpDiagStats.rtpsPzMax = temp.pz;
+		} else {
+			g_pgxpDiagStats.rtpsPzMin = min(g_pgxpDiagStats.rtpsPzMin, temp.pz);
+			g_pgxpDiagStats.rtpsPzMax = max(g_pgxpDiagStats.rtpsPzMax, temp.pz);
+		}
+
+		g_pgxpDiagStats.rtpsCount++;
+
+		if (fMAC3 <= 0.0)
+			g_pgxpDiagStats.rtpsMac3Behind++;
+
+		if (temp.pz <= 0.0f)
+			g_pgxpDiagStats.rtpsPzBehind++;
+		else if (temp.pz <= 0.25f)
+			g_pgxpDiagStats.rtpsPzNear++;
+	}
 
 	// calculate projected values for cache
 	temp.x = (double(C2_OFX) + double(float(C2_IR1) * float(h_over_sz3))) / float(1 << 16);
@@ -432,7 +737,7 @@ int GTE_RotTransPers(int idx, int lm)
 	vdata.ofy = float(C2_OFY) / float(1 << 16);
 	vdata.scr_h = float(C2_H);
 
-	PGXP_EmitCacheData(&vdata);
+	g_FP_SXYZ2Index = PGXP_EmitCacheData(&vdata);
 #endif
 
 	return h_over_sz3;
@@ -470,35 +775,7 @@ int GTE_operator(int op)
 		GTELOG("%08x NCLIP", op);
 #endif
 #if USE_PGXP
-
-		if(g_cfg_pgxpTextureCorrection)
-		{
-			struct fvec3 {
-				float x, y, z;
-			};
-			static auto subtractVec = [](const fvec3& u, const fvec3& v) -> fvec3 {
-				return fvec3{ u.x - v.x, u.y - v.y, u.z - v.z };
-			};
-			static auto crossProduct = [](const fvec3& u, const fvec3& v) -> fvec3 {
-				return fvec3{ u.y * v.z - v.y * u.z, u.z * v.x - u.x * v.z, u.x * v.y - u.y * v.x };
-			};
-			static auto dotProduct = [](const fvec3& u, const fvec3& v) -> float {
-				return u.x * v.x + u.y * v.y + u.z * v.z;
-			};
-			static auto normalize = [](const fvec3& v) -> fvec3 {
-				const float invLen = 1.0f / sqrtf(dotProduct(v, v));
-				return fvec3{ v.x * invLen, v.y * invLen, v.z * invLen };
-			};
-
-			// treat our PGXP triangle as plane
-			const fvec3 v0 = *(fvec3*)&g_FP_SXYZ0;
-			const fvec3 v1 = *(fvec3*)&g_FP_SXYZ1;
-			const fvec3 v2 = *(fvec3*)&g_FP_SXYZ2;
-			const fvec3 normal = normalize(crossProduct(subtractVec(v2, v1), subtractVec(v0, v1)));
-
-			C2_MAC0 = dotProduct(v0, normal) < 0 ? -1 : 1;
-		}
-		else
+		// PSX NCLIP is the signed 2D screen-space area; keep PGXP culling on the same value.
 		{
 			float fSX0 = g_FP_SXYZ0.x;
 			float fSY0 = g_FP_SXYZ0.y;
@@ -517,6 +794,15 @@ int GTE_operator(int op)
 				nclip += (nclip < 0.0f) ? -1.0f : 1.0f;
 
 			C2_MAC0 = nclip;
+		}
+
+		if (PGXP_DiagEnabled()) {
+			if (C2_MAC0 > 0)
+				g_pgxpDiagStats.nclipPositive++;
+			else if (C2_MAC0 < 0)
+				g_pgxpDiagStats.nclipNegative++;
+			else
+				g_pgxpDiagStats.nclipZero++;
 		}
 #else
 		C2_MAC0 = int(F((long long)(C2_SX0 * C2_SY1) + (C2_SX1 * C2_SY2) + (C2_SX2 * C2_SY0) - (C2_SX0 * C2_SY2) - (C2_SX1 * C2_SY0) - (C2_SX2 * C2_SY1)));

--- a/src/psx/LIBCD.C
+++ b/src/psx/LIBCD.C
@@ -8,11 +8,13 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
+#if !defined(__APPLE__)
 #include <malloc.h>
+#endif
 
 #ifdef _WIN32
 #include <direct.h>
-#elif defined (__unix__)
+#elif defined (__unix__) || defined(__APPLE__)
 #include <sys/stat.h>
 #define _mkdir(str)				mkdir(str, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
 #endif
@@ -582,7 +584,7 @@ int CdSync(int mode, u_char * result)
 			if (readMode == RM_XA_AUDIO)
 			{
 				char xaAudioData[2336];
-				CdRead(1, (u_long*)&xaAudioData[0], CdlReadS);
+				CdRead(1, (unsigned int*)&xaAudioData[0], CdlReadS);
 				CdReadSync(CdlReadS, NULL);
 
 				//Sector should be read now

--- a/src/psx/LIBETC.C
+++ b/src/psx/LIBETC.C
@@ -23,7 +23,7 @@ int StopCallback(void)
 
 int ResetCallback(void)
 {
-	int old = (int)vsync_callback;
+	int old = (int)(intptr_t)vsync_callback;
 	vsync_callback = NULL;
 	return old;
 }
@@ -50,7 +50,7 @@ int VSync(int mode)
 
 int VSyncCallback(void(*f)(void))
 {
-	int old = (int)vsync_callback;
+	int old = (int)(intptr_t)vsync_callback;
 	vsync_callback = f;
 	return old;
 }

--- a/src/psx/LIBGPU.C
+++ b/src/psx/LIBGPU.C
@@ -456,7 +456,7 @@ void DrawPrim(void* p)
 	//if (activeDrawEnv.isbg)
 	//	ClearImage(&activeDrawEnv.clip, activeDrawEnv.r0, activeDrawEnv.g0, activeDrawEnv.b0);
 
- 	ParsePrimitivesLinkedList((u_long*)p, 1);
+ 	ParsePrimitivesLinkedList((u_int*)p, 1);
 }
 
 void SetSprt16(SPRT_16* p)
@@ -509,7 +509,7 @@ void FntLoad(int x, int y)
 	RECT16 pos;
 	TIM_IMAGE tim;
 
-	GetTimInfo((u_long*)dbugfont, &tim);
+	GetTimInfo((u_int*)dbugfont, &tim);
 
 	// Load font image
 	pos = *tim.pRECT16;
@@ -518,7 +518,7 @@ void FntLoad(int x, int y)
 
 	_font_tpage = getTPage(0, 0, pos.x, pos.y);
 
-	LoadImage(&pos, (u_long*)tim.paddr);
+	LoadImage(&pos, tim.paddr);
 	DrawSync(0);
 
 	// Load font clut
@@ -528,7 +528,7 @@ void FntLoad(int x, int y)
 
 	_font_clut = getClut(pos.x, pos.y);
 
-	LoadImage(&pos, (u_long*)tim.caddr);
+	LoadImage(&pos, tim.caddr);
 	DrawSync(0);
 
 	// Clear previously opened text streams
@@ -605,7 +605,7 @@ u_short LoadTPage(u_int* pix, int tp, int abr, int x, int y, int w, int h)
 	}
 
 	//loc_2AC
-	LoadImage(&imageArea, (u_long*)pix);
+	LoadImage(&imageArea, pix);
 	return GetTPage(tp, abr, x, y) & 0xFFFF;
 }
 

--- a/src/render/PsyX_render.cpp
+++ b/src/render/PsyX_render.cpp
@@ -30,16 +30,26 @@ extern "C" {
 
 #if defined(RENDERER_OGL)
 
+// On macOS Apple Silicon, OpenGL is implemented on top of Metal and the
+// async framebuffer-blit + PBO path produces flickering geometry / dropped
+// primitives. Disabling these forces a synchronous, simpler path that
+// matches what the renderer assumes.
+#if defined(__APPLE__)
+#define USE_PBO					0
+#define USE_OFFSCREEN_BLIT		0
+#define USE_FRAMEBUFFER_BLIT	0
+#else
 #define USE_PBO					1
 #define USE_OFFSCREEN_BLIT		1
 #define USE_FRAMEBUFFER_BLIT	1
+#endif
 
 #else
 
 // OpenGL ES/Web GL has slowdowns and doesn't allow GL_LUMINANCE_ALPHA format as framebuffer, so it's disabled
-#define USE_PBO					(OGLES_VERSION == 3)
-#define USE_OFFSCREEN_BLIT		(OGLES_VERSION == 3)
-#define USE_FRAMEBUFFER_BLIT	(OGLES_VERSION == 3)
+#define USE_PBO					0
+#define USE_OFFSCREEN_BLIT		0
+#define USE_FRAMEBUFFER_BLIT	0
 
 #endif
 
@@ -123,14 +133,6 @@ int PBO_Init(GrPBO* pbo, GLenum format, int w, int h, int num)
 	pbo->width = w;
 	pbo->height = h;
 	pbo->num_pbos = num;
-
-#ifndef GL_BGR
-#define GL_BGR 0x80E0
-#endif
-
-#ifndef GL_BGRA
-#define GL_BGRA 0x80E1
-#endif
 
 #if USE_PBO
 	if (GL_RED == pbo->fmt || GL_GREEN == pbo->fmt || GL_BLUE == pbo->fmt) {
@@ -279,9 +281,6 @@ int GR_InitialiseGLContext(char* windowName, int fullscreen)
 	if (fullscreen)
 		windowFlags |= SDL_WINDOW_FULLSCREEN;
 #endif
-
-	if(g_windowWidth <= 0 || g_windowHeight <= 0)
-		windowFlags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 
 	g_window = SDL_CreateWindow(windowName, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, g_windowWidth, g_windowHeight, windowFlags);
 
@@ -905,12 +904,10 @@ TextureID GR_CreateRGBATexture(int width, int height, u_char* data /*= nullptr*/
 	glBindTexture(GL_TEXTURE_2D, newTexture);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, g_cfg_bilinearFiltering ? GL_LINEAR : GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, g_cfg_bilinearFiltering ? GL_LINEAR : GL_NEAREST);
-	
-	// another WebGL stuff. Texture will be black without clamp to edge
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
+	//glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
+	//glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+
 	glBindTexture(GL_TEXTURE_2D, 0);
 
 	return newTexture;
@@ -1242,7 +1239,7 @@ void GR_SetTexture(TextureID texture, TexFormat texFormat)
 		break;
 	case TF_32_BIT_RGBA:
 		GR_SetShader(g_gte_shader_32_rgba.shader);
-		u_bilinearFilterLoc = -1;
+		u_bilinearFilterLoc = g_gte_shader_32_rgba.bilinearFilterLoc;
 		u_projectionLoc = g_gte_shader_32_rgba.projectionLoc;
 		u_projection3DLoc = g_gte_shader_32_rgba.projection3DLoc;
 		u_texelSizeLoc = g_gte_shader_32_rgba.texelSizeLoc;
@@ -1259,9 +1256,7 @@ void GR_SetTexture(TextureID texture, TexFormat texFormat)
 
 #if USE_OPENGL
 	glBindTexture(GL_TEXTURE_2D, texture);
-	if(u_bilinearFilterLoc != -1)
-		glUniform1i(u_bilinearFilterLoc, g_cfg_bilinearFiltering);
-
+	glUniform1i(u_bilinearFilterLoc, g_cfg_bilinearFiltering);
 #endif
 
 	g_lastBoundTexture = texture;
@@ -1269,12 +1264,7 @@ void GR_SetTexture(TextureID texture, TexFormat texFormat)
 
 void GR_SetOverrideTextureSize(int width, int height)
 {
-	if(u_texelSizeLoc == -1)
-		return;
-
-	// WebGL is fucking around with glUniform2f, so use vector version
-	float vec[] = { 1.0f / (float)width, 1.0f / (float)height };
-	glUniform2fv(u_texelSizeLoc, 1, vec);
+	glUniform2f(u_texelSizeLoc, 1.0f / (float)width, 1.0f / (float)height);
 }
 
 void GR_DestroyTexture(TextureID texture)
@@ -1847,8 +1837,8 @@ void GR_DrawTriangles(int start_vertex, int triangles)
 
 void GR_PushDebugLabel(const char* label)
 {
-#if USE_OPENGL && !defined(__EMSCRIPTEN__) && defined(GL_DEBUG_SOURCE_APPLICATION)
-	if (!glPushDebugGroup)
+#if USE_OPENGL
+	if (!GLAD_GL_KHR_debug)
 		return;
 	glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0x8000, strlen(label), label);
 #endif
@@ -1856,8 +1846,8 @@ void GR_PushDebugLabel(const char* label)
 
 void GR_PopDebugLabel()
 {
-#if USE_OPENGL && !defined(__EMSCRIPTEN__) && defined(GL_DEBUG_SOURCE_APPLICATION)
-	if (!glPopDebugGroup)
+#if USE_OPENGL
+	if (!GLAD_GL_KHR_debug)
 		return;
 	glPopDebugGroup();
 #endif

--- a/src/render/PsyX_render_vk.cpp
+++ b/src/render/PsyX_render_vk.cpp
@@ -1,0 +1,1846 @@
+// PsyX_render_vk.cpp
+//
+// Vulkan / MoltenVK rendering backend for Psy-X.
+// Companion to (and selectable alternative to) the OpenGL backend in
+// PsyX_render.cpp. Build is enabled by RENDERER_VK (premake5 --renderer=vulkan).
+//
+// State of this revision:
+//   - Vulkan instance + surface + device + swapchain bring-up via SDL2.
+//   - Per-frame BeginScene → render-pass → command-buffer → submit → present.
+//   - GR_Shader_Compile compiles GLSL source to SPIR-V at runtime via
+//     libshaderc (statically linked).
+//   - A single "PSX vertex" graphics pipeline is created at GR_InitialisePSX
+//     time, matching the GrVertex layout. GR_UpdateVertexBuffer fills a
+//     mappable host-visible vertex buffer. GR_DrawTriangles binds and draws.
+//   - GR_SetBlendMode toggles between a small set of pre-baked PSO variants.
+//   - VRAM image, paletted texture sampling, full GTE shader port,
+//     framebuffer→VRAM blit and PGXP Z-buffer are still TODO and are
+//     stubbed out (they no-op cleanly so the rest of the engine runs).
+//
+// All identifiers exposed to PsyX_main / PsyX_GPU keep the same C++ linkage
+// the OpenGL backend uses; the public GR_* surface lives in PsyX_render.h.
+
+#include "PsyX/PsyX_render.h"
+
+#if defined(RENDERER_VK)
+
+#include "PsyX/PsyX_globals.h"
+#include "PsyX/PsyX_public.h"
+#include "../PsyX_main.h"
+#include "../platform.h"
+
+#include <vulkan/vulkan.h>
+#include <SDL_vulkan.h>
+#include <shaderc/shaderc.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <vector>
+#include <algorithm>
+#include <unordered_map>
+
+// =======================================================================
+// Engine-side globals (parity with GL backend)
+// =======================================================================
+
+extern "C" {
+
+extern SDL_Window* g_window;	// owned by PsyX_main.cpp
+
+int g_windowWidth  = 0;
+int g_windowHeight = 0;
+
+int g_dbg_wireframeMode  = 0;
+int g_dbg_texturelessMode = 0;
+
+int g_cfg_pgxpTextureCorrection = 1;
+int g_cfg_pgxpZBuffer           = 1;
+int g_cfg_bilinearFiltering     = 0;
+
+TextureID g_whiteTexture = 0;
+TextureID g_vramTexture  = 0;
+
+int g_PreviousBlendMode    = BM_NONE;
+int g_PreviousDepthMode    = 0;
+int g_PreviousStencilMode  = 0;
+int g_PreviousScissorState = 0;
+int g_PreviousOffscreenState = 0;
+ShaderID g_PreviousShader  = (ShaderID)-1;
+TextureID g_lastBoundTexture = (TextureID)-1;
+
+int vram_need_update         = 1;
+int framebuffer_need_update  = 0;
+
+}
+
+// =======================================================================
+// Vulkan backend internals
+// =======================================================================
+
+namespace {
+
+// -----------------------------------------------------------------------
+// Core Vulkan handles
+// -----------------------------------------------------------------------
+VkInstance         g_vkInstance        = VK_NULL_HANDLE;
+VkPhysicalDevice   g_vkPhysicalDevice  = VK_NULL_HANDLE;
+VkDevice           g_vkDevice          = VK_NULL_HANDLE;
+VkSurfaceKHR       g_vkSurface         = VK_NULL_HANDLE;
+VkQueue            g_vkGraphicsQueue   = VK_NULL_HANDLE;
+VkQueue            g_vkPresentQueue    = VK_NULL_HANDLE;
+uint32_t           g_vkGraphicsQueueFamily = 0;
+uint32_t           g_vkPresentQueueFamily  = 0;
+VkPhysicalDeviceMemoryProperties g_vkMemProps = {};
+
+VkSwapchainKHR     g_vkSwapchain       = VK_NULL_HANDLE;
+VkFormat           g_vkSwapchainFormat = VK_FORMAT_UNDEFINED;
+VkExtent2D         g_vkSwapchainExtent = {0, 0};
+std::vector<VkImage>     g_vkSwapchainImages;
+std::vector<VkImageView> g_vkSwapchainImageViews;
+std::vector<VkFramebuffer> g_vkFramebuffers;
+
+// Depth attachment shared by every framebuffer (depth contents are
+// cleared each frame so we don't need per-image instances).
+VkImage            g_vkDepthImage      = VK_NULL_HANDLE;
+VkDeviceMemory     g_vkDepthImageMem   = VK_NULL_HANDLE;
+VkImageView        g_vkDepthImageView  = VK_NULL_HANDLE;
+const VkFormat     g_vkDepthFormat     = VK_FORMAT_D32_SFLOAT;
+
+VkRenderPass       g_vkClearRenderPass = VK_NULL_HANDLE;
+
+VkCommandPool      g_vkCommandPool     = VK_NULL_HANDLE;
+static const int   kMaxFramesInFlight  = 2;
+VkCommandBuffer    g_vkCmdBuffers[kMaxFramesInFlight] = {};
+VkSemaphore        g_vkImageAvailableSems[kMaxFramesInFlight] = {};
+VkSemaphore        g_vkRenderFinishedSems[kMaxFramesInFlight] = {};
+VkFence            g_vkInFlightFences[kMaxFramesInFlight] = {};
+
+int                g_vkCurrentFrame    = 0;
+uint32_t           g_vkAcquiredImageIdx = 0;
+bool               g_vkSceneRecording  = false;
+
+float              g_vkClearColor[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
+
+// -----------------------------------------------------------------------
+// Pipeline / drawing state
+// -----------------------------------------------------------------------
+
+// libshaderc compiler context — created once at startup, reused for every
+// GR_Shader_Compile call.
+shaderc_compiler_t   g_shadercCompiler = nullptr;
+
+// One graphics pipeline per PSX blend mode. GR_SetBlendMode picks the
+// active one; GR_DrawTriangles re-binds if it differs from what's
+// currently bound on the command buffer.
+VkPipelineLayout     g_vkPipelineLayout = VK_NULL_HANDLE;
+VkPipeline           g_vkPipelines[5]   = {}; // indexed by BlendMode enum
+int                  g_vkBoundPipelineIdx = -1;
+int                  g_vkActiveBlendMode  = BM_NONE;
+
+// Default vertex/fragment shader modules used by the solid pipeline.
+VkShaderModule       g_vkVertModule = VK_NULL_HANDLE;
+VkShaderModule       g_vkFragModule = VK_NULL_HANDLE;
+
+// VRAM image — 1024×512 of 16-bit packed pixels exposed to the shader as
+// R8G8_UNORM (low byte = R, high byte = G). Mirrors what the GL backend
+// uploads as GL_RG via GL_UNSIGNED_BYTE.
+VkImage              g_vkVramImage      = VK_NULL_HANDLE;
+VkDeviceMemory       g_vkVramImageMem   = VK_NULL_HANDLE;
+VkImageView          g_vkVramImageView  = VK_NULL_HANDLE;
+VkSampler            g_vkVramSampler    = VK_NULL_HANDLE;
+
+// Staging buffer used to upload the CPU-side `vram[]` to the GPU image.
+VkBuffer             g_vkVramStaging      = VK_NULL_HANDLE;
+VkDeviceMemory       g_vkVramStagingMem   = VK_NULL_HANDLE;
+void*                g_vkVramStagingMap   = nullptr;
+
+// Descriptor set layout / pool / set bound to the pipeline at slot 0.
+VkDescriptorSetLayout g_vkDescSetLayout = VK_NULL_HANDLE;
+VkDescriptorPool      g_vkDescPool      = VK_NULL_HANDLE;
+VkDescriptorSet       g_vkDescSet       = VK_NULL_HANDLE;
+
+bool                 g_vkVramDirty      = true;
+
+// Vertex buffer (host-visible, persistently mapped). Sized to PsyX's
+// MAX_VERTEX_BUFFER_SIZE upper bound.
+VkBuffer             g_vkVertexBuffer = VK_NULL_HANDLE;
+VkDeviceMemory       g_vkVertexBufferMem = VK_NULL_HANDLE;
+void*                g_vkVertexBufferMap = nullptr;
+uint32_t             g_vkVertexBufferSize = 0; // in vertices currently uploaded
+
+// Push constants — both projection matrices in one block. Vulkan
+// guarantees at least 128 bytes of push constant space (most desktop
+// GPUs and MoltenVK expose more). The PGXP vertex path needs both the
+// 2D ortho (HUD/menus) and the 3D perspective (world geometry); the
+// vertex shader picks one based on a_zw.y > 100.
+struct PushBlock {
+	float Projection[16];    // 64 B — 2D ortho
+	float Projection3D[16];  // 64 B — 3D perspective (PGXP world path)
+};
+static_assert(sizeof(PushBlock) == 128, "Push constants tuned to the 128 B core minimum");
+
+PushBlock           g_vkPushBlock = {
+	// Identity for both projections so the very first frames (before the
+	// game calls GR_Ortho2D / GR_Perspective3D) don't collapse every
+	// vertex onto the origin via a zero matrix.
+	{ 1,0,0,0,  0,1,0,0,  0,0,1,0,  0,0,0,1 },
+	{ 1,0,0,0,  0,1,0,0,  0,0,1,0,  0,0,0,1 },
+};
+
+// CPU-side VRAM mirror — same layout as the GL backend's `vram[]`.
+unsigned short g_vkVramCPU[VRAM_WIDTH * VRAM_HEIGHT] = {};
+
+// =======================================================================
+// Helpers
+// =======================================================================
+
+#define VK_CHECK(expr)                                                \
+	do {                                                              \
+		VkResult _r = (expr);                                         \
+		if (_r != VK_SUCCESS) {                                       \
+			eprinterr("Vulkan call failed: %s -> %d\n", #expr, _r);   \
+		}                                                             \
+	} while (0)
+
+uint32_t FindMemoryTypeIndex(uint32_t typeBits, VkMemoryPropertyFlags wanted)
+{
+	for (uint32_t i = 0; i < g_vkMemProps.memoryTypeCount; ++i) {
+		if ((typeBits & (1u << i)) &&
+			(g_vkMemProps.memoryTypes[i].propertyFlags & wanted) == wanted) {
+			return i;
+		}
+	}
+	eprinterr("FindMemoryTypeIndex: no compatible heap (typeBits=0x%x wanted=0x%x)\n",
+		typeBits, (unsigned)wanted);
+	return 0;
+}
+
+bool CreateImage(uint32_t w, uint32_t h, VkFormat format, VkImageUsageFlags usage,
+                 VkImage* outImg, VkDeviceMemory* outMem)
+{
+	VkImageCreateInfo ci = {};
+	ci.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+	ci.imageType = VK_IMAGE_TYPE_2D;
+	ci.format = format;
+	ci.extent = { w, h, 1 };
+	ci.mipLevels = 1;
+	ci.arrayLayers = 1;
+	ci.samples = VK_SAMPLE_COUNT_1_BIT;
+	ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+	ci.usage = usage;
+	ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+	ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+	VK_CHECK(vkCreateImage(g_vkDevice, &ci, nullptr, outImg));
+
+	VkMemoryRequirements mr;
+	vkGetImageMemoryRequirements(g_vkDevice, *outImg, &mr);
+	VkMemoryAllocateInfo ai = {};
+	ai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+	ai.allocationSize = mr.size;
+	ai.memoryTypeIndex = FindMemoryTypeIndex(mr.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	VK_CHECK(vkAllocateMemory(g_vkDevice, &ai, nullptr, outMem));
+	VK_CHECK(vkBindImageMemory(g_vkDevice, *outImg, *outMem, 0));
+	return true;
+}
+
+bool CreateBuffer(VkDeviceSize size, VkBufferUsageFlags usage,
+                  VkMemoryPropertyFlags memProps,
+                  VkBuffer* outBuffer, VkDeviceMemory* outMem)
+{
+	VkBufferCreateInfo bi = {};
+	bi.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+	bi.size = size;
+	bi.usage = usage;
+	bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+	VK_CHECK(vkCreateBuffer(g_vkDevice, &bi, nullptr, outBuffer));
+
+	VkMemoryRequirements mr;
+	vkGetBufferMemoryRequirements(g_vkDevice, *outBuffer, &mr);
+
+	VkMemoryAllocateInfo ai = {};
+	ai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+	ai.allocationSize = mr.size;
+	ai.memoryTypeIndex = FindMemoryTypeIndex(mr.memoryTypeBits, memProps);
+	VK_CHECK(vkAllocateMemory(g_vkDevice, &ai, nullptr, outMem));
+
+	VK_CHECK(vkBindBufferMemory(g_vkDevice, *outBuffer, *outMem, 0));
+	return true;
+}
+
+VkShaderModule CreateShaderModule(const uint32_t* spirv, size_t bytes)
+{
+	VkShaderModuleCreateInfo ci = {};
+	ci.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+	ci.codeSize = bytes;
+	ci.pCode    = spirv;
+	VkShaderModule m = VK_NULL_HANDLE;
+	VK_CHECK(vkCreateShaderModule(g_vkDevice, &ci, nullptr, &m));
+	return m;
+}
+
+VkShaderModule CompileGLSL(const char* source, shaderc_shader_kind kind, const char* tag)
+{
+	if (!g_shadercCompiler) {
+		eprinterr("CompileGLSL called before shaderc init\n");
+		return VK_NULL_HANDLE;
+	}
+	shaderc_compile_options_t opts = shaderc_compile_options_initialize();
+	shaderc_compile_options_set_optimization_level(opts, shaderc_optimization_level_performance);
+	shaderc_compile_options_set_target_env(opts, shaderc_target_env_vulkan, shaderc_env_version_vulkan_1_1);
+	shaderc_compile_options_set_source_language(opts, shaderc_source_language_glsl);
+
+	shaderc_compilation_result_t res = shaderc_compile_into_spv(
+		g_shadercCompiler, source, strlen(source), kind, tag, "main", opts);
+
+	shaderc_compilation_status status = shaderc_result_get_compilation_status(res);
+	if (status != shaderc_compilation_status_success) {
+		eprinterr("shaderc[%s] failed: %s\n", tag, shaderc_result_get_error_message(res));
+		shaderc_result_release(res);
+		shaderc_compile_options_release(opts);
+		return VK_NULL_HANDLE;
+	}
+
+	const uint32_t* code = (const uint32_t*)shaderc_result_get_bytes(res);
+	size_t bytes = shaderc_result_get_length(res);
+	VkShaderModule mod = CreateShaderModule(code, bytes);
+
+	shaderc_result_release(res);
+	shaderc_compile_options_release(opts);
+	return mod;
+}
+
+// -----------------------------------------------------------------------
+// Default shaders (PSX-vertex layout)
+// -----------------------------------------------------------------------
+//
+// GrVertex layout (see PsyX_render.h):
+//   #if USE_PGXP -> position is (x,y,page,clut, z,scr_h,ofsX,ofsY) as floats
+//   else         -> (x,y,page,clut) as int16
+//   then  u,v,bright,dither (u8x4)
+//   then  r,g,b,a            (u8x4)
+//   then  tcx,tcy,_p0,_p1    (i8x4)
+//
+// PsyX is built without USE_PGXP for now (the engine uses the int16 path),
+// so we declare matching attribute formats below. Texture sampling is
+// stubbed — for this revision the fragment shader just outputs vertex
+// colour directly. That is enough to start seeing world geometry.
+
+// PSX vertex shader (PGXP variant) and fragment shader.
+//
+// GrVertex layout with USE_PGXP=1:
+//   loc 0 (a_position) : float x, y, page, clut
+//   loc 1 (a_zw)       : float z, scr_h, ofsX, ofsY
+//   loc 2 (a_texcoord) : u8 raw  u, v, bright, dither   (0..255)
+//   loc 3 (a_color)    : u8 norm r, g, b, a             (0..1)
+//   loc 4 (a_extra)    : i8 raw  tcx, tcy, _p0, _p1     (-128..127)
+//
+// The fragment shader implements PSX paletted texture sampling against a
+// 1024×512 VRAM image exposed as R8G8_UNORM (low byte in .r, high byte
+// in .g — matches the GL backend's GL_RG / GL_UNSIGNED_BYTE upload).
+// Texture format is encoded in `clut` (0 = 4-bit, 1 = 8-bit, 2+ = 16-bit
+// direct). For a first pass the menu UI tends to be 8-bit.
+const char* kBasicVertSrc = R"GLSL(
+#version 450
+layout(location = 0) in vec4 a_position;
+layout(location = 1) in vec4 a_zw;
+layout(location = 2) in vec4 a_texcoord;
+layout(location = 3) in vec4 a_color;
+layout(location = 4) in vec4 a_extra;
+
+layout(push_constant) uniform PB {
+    mat4 Projection;
+    mat4 Projection3D;
+} pb;
+
+layout(location = 0) out vec4 v_color;
+layout(location = 1) out vec4 v_texcoord;
+layout(location = 2) out vec4 v_page_clut;
+
+void main() {
+    bool fmvLike = (a_zw.x == 0.0 && a_zw.y == 0.0 && a_color.a < 0.001);
+    if (fmvLike) {
+        gl_Position = vec4(a_position.xy, 0.5, 1.0);
+    } else if (a_zw.y > 100.0) {
+        gl_Position = pb.Projection3D * vec4(a_position.xy * a_zw.y, a_zw.x, 1.0);
+    } else {
+        gl_Position = pb.Projection * vec4(a_position.xy, 0.5, 1.0);
+    }
+
+    // GL→Vulkan NDC z remap. The projection matrices were copied verbatim
+    // from the OpenGL backend, which emits clip-space z in [-w, w] (NDC
+    // z ∈ [-1, 1]). Vulkan's clip volume is z ∈ [0, w] (NDC z ∈ [0, 1]),
+    // so without this remap every primitive lands outside the clip volume
+    // and gets discarded — leaving the screen black.
+    gl_Position.z = (gl_Position.z + gl_Position.w) * 0.5;
+    v_color = a_color;
+    v_texcoord = a_texcoord;
+
+    // PSX texture page → VRAM coords:
+    //   page is bits-packed: low 4 bits = X / 64, next 1 bit = Y / 256
+    //   the actual texture page format (4/8/16-bit) is in bits 7-8 of the
+    //   tpage word, but we receive `page` already split.
+    // For a first cut we extract:
+    //   page_x = (page & 0x0F) * 64
+    //   page_y = ((page >> 4) & 0x01) * 256
+    //   tex_format = (page >> 7) & 0x03   (0=4bit, 1=8bit, 2/3=16bit)
+    //   clut_x = (clut & 0x3F) * 16
+    //   clut_y = (clut >> 6)
+    // Pass them along so the fragment shader can sample.
+    float pageRaw = a_position.z;
+    float clutRaw = a_position.w;
+    float pageX = mod(pageRaw, 16.0) * 64.0;
+    float pageY = floor(pageRaw / 16.0);
+    pageY = mod(pageY, 2.0) * 256.0;
+    float texFormat = floor(pageRaw / 128.0);
+    texFormat = mod(texFormat, 4.0);
+    float clutX = mod(clutRaw, 64.0) * 16.0;
+    float clutY = floor(clutRaw / 64.0);
+    v_page_clut = vec4(pageX, pageY, clutX, clutY);
+    // Stash format in the otherwise-unused dither slot so the fragment
+    // shader picks the right decode path.
+    v_texcoord.w = texFormat;
+}
+)GLSL";
+
+const char* kBasicFragSrc = R"GLSL(
+#version 450
+layout(location = 0) in vec4 v_color;
+layout(location = 1) in vec4 v_texcoord;     // u, v, bright, texFormat
+layout(location = 2) in vec4 v_page_clut;    // pageX, pageY, clutX, clutY
+
+layout(location = 0) out vec4 out_color;
+
+// VRAM as R8G8 unorm (low byte = R, high byte = G).
+layout(set = 0, binding = 0) uniform sampler2D s_vram;
+
+const float VRAM_W = 1024.0;
+const float VRAM_H = 512.0;
+
+// Decode a 16-bit packed (low,high) byte pair to the raw u16 value.
+float pack_rg_u16(vec2 rg) {
+    return floor(rg.x * 255.0 + 0.5) + floor(rg.y * 255.0 + 0.5) * 256.0;
+}
+
+// PSX 16-bit pixel — bits 0-4 = R, 5-9 = G, 10-14 = B, bit 15 = STP
+// (semitransparency / mask). When STP=0 the pixel is opaque (alpha=1),
+// when STP=1 it should blend with the active ABR mode (alpha=0.5 so
+// VK_BLEND_FACTOR_SRC_ALPHA in the BM_AVERAGE pipeline produces the
+// 50/50 mix the PSX expects; the BM_ADD/SUBTRACT pipelines ignore the
+// alpha because their factors are ONE/ONE).
+vec4 psx16_to_rgba(float v16) {
+    float r = mod(v16, 32.0);                v16 = floor(v16 / 32.0);
+    float g = mod(v16, 32.0);                v16 = floor(v16 / 32.0);
+    float b = mod(v16, 32.0);                v16 = floor(v16 / 32.0);
+    float stp = mod(v16, 2.0);  // 0 or 1
+    return vec4(r / 31.0, g / 31.0, b / 31.0, stp > 0.5 ? 0.5 : 1.0);
+}
+
+// Read the raw 16-bit value at integer VRAM (x,y).
+float read_vram_u16(float x, float y) {
+    vec2 uv = vec2((x + 0.5) / VRAM_W, (y + 0.5) / VRAM_H);
+    return pack_rg_u16(texture(s_vram, uv).rg);
+}
+
+void main() {
+    // bright (a_texcoord.z, raw u8 0..255) is the engine's untextured
+    // marker: PsyX_GPU::MakeTexcoordTriangleZero/QuadZero set bright=1
+    // for untextured fills, MakeTexcoordTriangle/Quad sets bright=2 for
+    // textured ones. So bright<=1.5 → no texture sampling, just vertex
+    // colour. Avoids the "page=0+uv=0 happens to be a real texel"
+    // ambiguity that previously made the player character grey.
+    if (v_texcoord.z < 1.5) {
+        out_color = vec4(min(v_color.rgb * 2.0, vec3(1.0)), 1.0);
+        return;
+    }
+
+    // FLOOR the interpolated UV to integer texel coordinates BEFORE doing
+    // any palette-index math. Otherwise sub-texel fractions leak into
+    // mod(u,2)/mod(u,4)/pow(16,sub) and produce wrong palette indices,
+    // which manifests as the high-frequency noise pattern across the whole
+    // textured surface.
+    float u = floor(v_texcoord.x + 0.0001);   // 0..255 integer texel
+    float v = floor(v_texcoord.y + 0.0001);
+    float fmt = v_texcoord.w;      // 0=4bit, 1=8bit, 2/3=16bit
+    vec2 page = v_page_clut.xy;
+    vec2 clut = v_page_clut.zw;
+
+    vec4 texel;
+    if (fmt < 0.5) {
+        // 4-bit paletted: 4 pixels per VRAM cell
+        float cellX = page.x + floor(u / 4.0);
+        float cellY = page.y + v;
+        float cell  = read_vram_u16(cellX, cellY);
+        float subX  = mod(u, 4.0);
+        float nibble = floor(cell / pow(16.0, subX));
+        nibble = mod(nibble, 16.0);
+        float c16 = read_vram_u16(clut.x + nibble, clut.y);
+        if (c16 == 0.0) discard;
+        texel = psx16_to_rgba(c16);
+    } else if (fmt < 1.5) {
+        // 8-bit paletted: 2 pixels per VRAM cell
+        float cellX = page.x + floor(u / 2.0);
+        float cellY = page.y + v;
+        float cell  = read_vram_u16(cellX, cellY);
+        float idx   = (mod(u, 2.0) < 0.5) ? mod(cell, 256.0) : floor(cell / 256.0);
+        float c16   = read_vram_u16(clut.x + idx, clut.y);
+        if (c16 == 0.0) discard;
+        texel = psx16_to_rgba(c16);
+    } else {
+        // 16-bit direct
+        float c16 = read_vram_u16(page.x + u, page.y + v);
+        if (c16 == 0.0) discard;
+        texel = psx16_to_rgba(c16);
+    }
+
+    // PSX modulates texel by 2× the vertex colour (rgba=128 → 1.0).
+    out_color = vec4(texel.rgb * min(v_color.rgb * 2.0, vec3(1.0)), texel.a);
+}
+)GLSL";
+
+// -----------------------------------------------------------------------
+// Initialisation chain
+// -----------------------------------------------------------------------
+
+bool PickPhysicalDeviceAndQueueFamilies()
+{
+	uint32_t count = 0;
+	vkEnumeratePhysicalDevices(g_vkInstance, &count, nullptr);
+	if (count == 0) {
+		eprinterr("No Vulkan-capable physical devices found\n");
+		return false;
+	}
+	std::vector<VkPhysicalDevice> devices(count);
+	vkEnumeratePhysicalDevices(g_vkInstance, &count, devices.data());
+
+	VkPhysicalDevice chosen = VK_NULL_HANDLE;
+	for (auto d : devices) {
+		VkPhysicalDeviceProperties props;
+		vkGetPhysicalDeviceProperties(d, &props);
+		if (chosen == VK_NULL_HANDLE) chosen = d;
+		if (props.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) {
+			chosen = d;
+			break;
+		}
+	}
+	g_vkPhysicalDevice = chosen;
+
+	VkPhysicalDeviceProperties props;
+	vkGetPhysicalDeviceProperties(g_vkPhysicalDevice, &props);
+	eprintinfo("Vulkan device: %s (API %u.%u.%u)\n",
+		props.deviceName,
+		VK_VERSION_MAJOR(props.apiVersion),
+		VK_VERSION_MINOR(props.apiVersion),
+		VK_VERSION_PATCH(props.apiVersion));
+
+	vkGetPhysicalDeviceMemoryProperties(g_vkPhysicalDevice, &g_vkMemProps);
+
+	uint32_t qfCount = 0;
+	vkGetPhysicalDeviceQueueFamilyProperties(g_vkPhysicalDevice, &qfCount, nullptr);
+	std::vector<VkQueueFamilyProperties> qfProps(qfCount);
+	vkGetPhysicalDeviceQueueFamilyProperties(g_vkPhysicalDevice, &qfCount, qfProps.data());
+
+	bool foundGfx = false, foundPresent = false;
+	for (uint32_t i = 0; i < qfCount; ++i) {
+		if (!foundGfx && (qfProps[i].queueFlags & VK_QUEUE_GRAPHICS_BIT)) {
+			g_vkGraphicsQueueFamily = i;
+			foundGfx = true;
+		}
+		VkBool32 presentSupport = VK_FALSE;
+		vkGetPhysicalDeviceSurfaceSupportKHR(g_vkPhysicalDevice, i, g_vkSurface, &presentSupport);
+		if (!foundPresent && presentSupport) {
+			g_vkPresentQueueFamily = i;
+			foundPresent = true;
+		}
+	}
+	if (!foundGfx || !foundPresent) {
+		eprinterr("Vulkan: no suitable queue families (gfx=%d present=%d)\n",
+			(int)foundGfx, (int)foundPresent);
+		return false;
+	}
+	return true;
+}
+
+bool CreateLogicalDevice()
+{
+	float qPriority = 1.0f;
+	std::vector<VkDeviceQueueCreateInfo> queueInfos;
+	std::vector<uint32_t> uniqueFamilies = { g_vkGraphicsQueueFamily };
+	if (g_vkPresentQueueFamily != g_vkGraphicsQueueFamily) {
+		uniqueFamilies.push_back(g_vkPresentQueueFamily);
+	}
+	for (uint32_t fam : uniqueFamilies) {
+		VkDeviceQueueCreateInfo qi = {};
+		qi.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+		qi.queueFamilyIndex = fam;
+		qi.queueCount = 1;
+		qi.pQueuePriorities = &qPriority;
+		queueInfos.push_back(qi);
+	}
+
+	std::vector<const char*> deviceExts = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
+#if defined(__APPLE__)
+	deviceExts.push_back("VK_KHR_portability_subset");
+#endif
+
+	VkPhysicalDeviceFeatures features = {};
+
+	VkDeviceCreateInfo ci = {};
+	ci.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+	ci.queueCreateInfoCount = (uint32_t)queueInfos.size();
+	ci.pQueueCreateInfos    = queueInfos.data();
+	ci.enabledExtensionCount = (uint32_t)deviceExts.size();
+	ci.ppEnabledExtensionNames = deviceExts.data();
+	ci.pEnabledFeatures = &features;
+	VK_CHECK(vkCreateDevice(g_vkPhysicalDevice, &ci, nullptr, &g_vkDevice));
+	if (g_vkDevice == VK_NULL_HANDLE) return false;
+
+	vkGetDeviceQueue(g_vkDevice, g_vkGraphicsQueueFamily, 0, &g_vkGraphicsQueue);
+	vkGetDeviceQueue(g_vkDevice, g_vkPresentQueueFamily, 0, &g_vkPresentQueue);
+	return true;
+}
+
+bool CreateSwapchain(int width, int height)
+{
+	VkSurfaceCapabilitiesKHR caps;
+	VK_CHECK(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(g_vkPhysicalDevice, g_vkSurface, &caps));
+
+	uint32_t fmtCount = 0;
+	vkGetPhysicalDeviceSurfaceFormatsKHR(g_vkPhysicalDevice, g_vkSurface, &fmtCount, nullptr);
+	std::vector<VkSurfaceFormatKHR> formats(fmtCount);
+	vkGetPhysicalDeviceSurfaceFormatsKHR(g_vkPhysicalDevice, g_vkSurface, &fmtCount, formats.data());
+
+	VkSurfaceFormatKHR chosen = formats[0];
+	for (auto& f : formats) {
+		if (f.format == VK_FORMAT_B8G8R8A8_UNORM &&
+			f.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
+			chosen = f; break;
+		}
+	}
+	g_vkSwapchainFormat = chosen.format;
+
+	VkExtent2D extent;
+	if (caps.currentExtent.width != 0xFFFFFFFFu) {
+		extent = caps.currentExtent;
+	} else {
+		extent.width  = std::max(caps.minImageExtent.width,  std::min(caps.maxImageExtent.width,  (uint32_t)width));
+		extent.height = std::max(caps.minImageExtent.height, std::min(caps.maxImageExtent.height, (uint32_t)height));
+	}
+	g_vkSwapchainExtent = extent;
+
+	uint32_t imgCount = caps.minImageCount + 1;
+	if (caps.maxImageCount > 0 && imgCount > caps.maxImageCount)
+		imgCount = caps.maxImageCount;
+
+	VkSwapchainCreateInfoKHR ci = {};
+	ci.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+	ci.surface = g_vkSurface;
+	ci.minImageCount = imgCount;
+	ci.imageFormat = chosen.format;
+	ci.imageColorSpace = chosen.colorSpace;
+	ci.imageExtent = extent;
+	ci.imageArrayLayers = 1;
+	ci.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+
+	uint32_t qf[2] = { g_vkGraphicsQueueFamily, g_vkPresentQueueFamily };
+	if (g_vkGraphicsQueueFamily != g_vkPresentQueueFamily) {
+		ci.imageSharingMode = VK_SHARING_MODE_CONCURRENT;
+		ci.queueFamilyIndexCount = 2;
+		ci.pQueueFamilyIndices = qf;
+	} else {
+		ci.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+	}
+
+	ci.preTransform = caps.currentTransform;
+	ci.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+	ci.presentMode = VK_PRESENT_MODE_FIFO_KHR;
+	ci.clipped = VK_TRUE;
+	VK_CHECK(vkCreateSwapchainKHR(g_vkDevice, &ci, nullptr, &g_vkSwapchain));
+	if (g_vkSwapchain == VK_NULL_HANDLE) return false;
+
+	uint32_t actualCount = 0;
+	vkGetSwapchainImagesKHR(g_vkDevice, g_vkSwapchain, &actualCount, nullptr);
+	g_vkSwapchainImages.resize(actualCount);
+	vkGetSwapchainImagesKHR(g_vkDevice, g_vkSwapchain, &actualCount, g_vkSwapchainImages.data());
+
+	g_vkSwapchainImageViews.resize(actualCount);
+	for (uint32_t i = 0; i < actualCount; ++i) {
+		VkImageViewCreateInfo vi = {};
+		vi.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+		vi.image = g_vkSwapchainImages[i];
+		vi.viewType = VK_IMAGE_VIEW_TYPE_2D;
+		vi.format = g_vkSwapchainFormat;
+		vi.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		vi.subresourceRange.levelCount = 1;
+		vi.subresourceRange.layerCount = 1;
+		VK_CHECK(vkCreateImageView(g_vkDevice, &vi, nullptr, &g_vkSwapchainImageViews[i]));
+	}
+	return true;
+}
+
+bool CreateClearRenderPass()
+{
+	VkAttachmentDescription atts[2] = {};
+	// 0: colour
+	atts[0].format = g_vkSwapchainFormat;
+	atts[0].samples = VK_SAMPLE_COUNT_1_BIT;
+	atts[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+	atts[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+	atts[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+	atts[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+	atts[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+	atts[0].finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+	// 1: depth
+	atts[1].format = g_vkDepthFormat;
+	atts[1].samples = VK_SAMPLE_COUNT_1_BIT;
+	atts[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+	atts[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+	atts[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+	atts[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+	atts[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+	atts[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+	VkAttachmentReference colorRef = {};
+	colorRef.attachment = 0;
+	colorRef.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+	VkAttachmentReference depthRef = {};
+	depthRef.attachment = 1;
+	depthRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+	VkSubpassDescription subpass = {};
+	subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+	subpass.colorAttachmentCount = 1;
+	subpass.pColorAttachments = &colorRef;
+	subpass.pDepthStencilAttachment = &depthRef;
+
+	VkSubpassDependency dep = {};
+	dep.srcSubpass = VK_SUBPASS_EXTERNAL;
+	dep.dstSubpass = 0;
+	dep.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+	                   VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+	dep.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+	                   VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+	dep.srcAccessMask = 0;
+	dep.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+	                    VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+
+	VkRenderPassCreateInfo rp = {};
+	rp.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+	rp.attachmentCount = 2;
+	rp.pAttachments = atts;
+	rp.subpassCount = 1;
+	rp.pSubpasses = &subpass;
+	rp.dependencyCount = 1;
+	rp.pDependencies = &dep;
+	VK_CHECK(vkCreateRenderPass(g_vkDevice, &rp, nullptr, &g_vkClearRenderPass));
+	return g_vkClearRenderPass != VK_NULL_HANDLE;
+}
+
+bool CreateDepthBuffer()
+{
+	if (!CreateImage(g_vkSwapchainExtent.width, g_vkSwapchainExtent.height,
+		g_vkDepthFormat, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
+		&g_vkDepthImage, &g_vkDepthImageMem)) {
+		return false;
+	}
+	VkImageViewCreateInfo vi = {};
+	vi.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+	vi.image = g_vkDepthImage;
+	vi.viewType = VK_IMAGE_VIEW_TYPE_2D;
+	vi.format = g_vkDepthFormat;
+	vi.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+	vi.subresourceRange.levelCount = 1;
+	vi.subresourceRange.layerCount = 1;
+	VK_CHECK(vkCreateImageView(g_vkDevice, &vi, nullptr, &g_vkDepthImageView));
+	return true;
+}
+
+bool CreateFramebuffers()
+{
+	g_vkFramebuffers.resize(g_vkSwapchainImageViews.size());
+	for (size_t i = 0; i < g_vkSwapchainImageViews.size(); ++i) {
+		VkImageView views[2] = { g_vkSwapchainImageViews[i], g_vkDepthImageView };
+		VkFramebufferCreateInfo ci = {};
+		ci.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+		ci.renderPass = g_vkClearRenderPass;
+		ci.attachmentCount = 2;
+		ci.pAttachments = views;
+		ci.width  = g_vkSwapchainExtent.width;
+		ci.height = g_vkSwapchainExtent.height;
+		ci.layers = 1;
+		VK_CHECK(vkCreateFramebuffer(g_vkDevice, &ci, nullptr, &g_vkFramebuffers[i]));
+	}
+	return true;
+}
+
+bool CreateCommandPoolAndBuffers()
+{
+	VkCommandPoolCreateInfo pi = {};
+	pi.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+	pi.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+	pi.queueFamilyIndex = g_vkGraphicsQueueFamily;
+	VK_CHECK(vkCreateCommandPool(g_vkDevice, &pi, nullptr, &g_vkCommandPool));
+
+	VkCommandBufferAllocateInfo ai = {};
+	ai.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+	ai.commandPool = g_vkCommandPool;
+	ai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+	ai.commandBufferCount = kMaxFramesInFlight;
+	VK_CHECK(vkAllocateCommandBuffers(g_vkDevice, &ai, g_vkCmdBuffers));
+	return true;
+}
+
+bool CreateSyncObjects()
+{
+	VkSemaphoreCreateInfo si = {};
+	si.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+	VkFenceCreateInfo fi = {};
+	fi.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+	fi.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+	for (int i = 0; i < kMaxFramesInFlight; ++i) {
+		VK_CHECK(vkCreateSemaphore(g_vkDevice, &si, nullptr, &g_vkImageAvailableSems[i]));
+		VK_CHECK(vkCreateSemaphore(g_vkDevice, &si, nullptr, &g_vkRenderFinishedSems[i]));
+		VK_CHECK(vkCreateFence(g_vkDevice, &fi, nullptr, &g_vkInFlightFences[i]));
+	}
+	return true;
+}
+
+// -----------------------------------------------------------------------
+// VRAM image + sampler + descriptor set
+// -----------------------------------------------------------------------
+
+bool CreateVramImage()
+{
+	if (!CreateImage(VRAM_WIDTH, VRAM_HEIGHT, VK_FORMAT_R8G8_UNORM,
+		VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+		&g_vkVramImage, &g_vkVramImageMem)) {
+		return false;
+	}
+
+	VkImageViewCreateInfo vi = {};
+	vi.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+	vi.image = g_vkVramImage;
+	vi.viewType = VK_IMAGE_VIEW_TYPE_2D;
+	vi.format = VK_FORMAT_R8G8_UNORM;
+	vi.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	vi.subresourceRange.levelCount = 1;
+	vi.subresourceRange.layerCount = 1;
+	VK_CHECK(vkCreateImageView(g_vkDevice, &vi, nullptr, &g_vkVramImageView));
+
+	VkSamplerCreateInfo si = {};
+	si.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+	si.magFilter = VK_FILTER_NEAREST;
+	si.minFilter = VK_FILTER_NEAREST;
+	si.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+	si.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+	si.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+	si.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+	si.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+	si.unnormalizedCoordinates = VK_FALSE;
+	si.compareEnable = VK_FALSE;
+	VK_CHECK(vkCreateSampler(g_vkDevice, &si, nullptr, &g_vkVramSampler));
+
+	// Staging buffer (host-visible, persistently mapped) for VRAM uploads.
+	const VkDeviceSize vramBytes = (VkDeviceSize)VRAM_WIDTH * VRAM_HEIGHT * sizeof(uint16_t);
+	if (!CreateBuffer(vramBytes,
+		VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+		VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+		&g_vkVramStaging, &g_vkVramStagingMem)) {
+		return false;
+	}
+	VK_CHECK(vkMapMemory(g_vkDevice, g_vkVramStagingMem, 0, VK_WHOLE_SIZE, 0, &g_vkVramStagingMap));
+	return true;
+}
+
+bool CreateDescriptorSet()
+{
+	VkDescriptorSetLayoutBinding b = {};
+	b.binding = 0;
+	b.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+	b.descriptorCount = 1;
+	b.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+	VkDescriptorSetLayoutCreateInfo lci = {};
+	lci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+	lci.bindingCount = 1;
+	lci.pBindings = &b;
+	VK_CHECK(vkCreateDescriptorSetLayout(g_vkDevice, &lci, nullptr, &g_vkDescSetLayout));
+
+	VkDescriptorPoolSize ps = {};
+	ps.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+	ps.descriptorCount = 1;
+	VkDescriptorPoolCreateInfo pci = {};
+	pci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+	pci.maxSets = 1;
+	pci.poolSizeCount = 1;
+	pci.pPoolSizes = &ps;
+	VK_CHECK(vkCreateDescriptorPool(g_vkDevice, &pci, nullptr, &g_vkDescPool));
+
+	VkDescriptorSetAllocateInfo ai = {};
+	ai.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+	ai.descriptorPool = g_vkDescPool;
+	ai.descriptorSetCount = 1;
+	ai.pSetLayouts = &g_vkDescSetLayout;
+	VK_CHECK(vkAllocateDescriptorSets(g_vkDevice, &ai, &g_vkDescSet));
+
+	VkDescriptorImageInfo ii = {};
+	ii.imageView = g_vkVramImageView;
+	ii.sampler = g_vkVramSampler;
+	ii.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+	VkWriteDescriptorSet w = {};
+	w.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+	w.dstSet = g_vkDescSet;
+	w.dstBinding = 0;
+	w.descriptorCount = 1;
+	w.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+	w.pImageInfo = &ii;
+	vkUpdateDescriptorSets(g_vkDevice, 1, &w, 0, nullptr);
+	return true;
+}
+
+// Helper: transitions the VRAM image between layouts inside the given
+// command buffer. Used during initial transition to SHADER_READ_ONLY and
+// when we copy from staging buffer.
+void VramImageBarrier(VkCommandBuffer cb,
+                      VkImageLayout oldL, VkImageLayout newL,
+                      VkAccessFlags srcA, VkAccessFlags dstA,
+                      VkPipelineStageFlags srcStage, VkPipelineStageFlags dstStage)
+{
+	VkImageMemoryBarrier b = {};
+	b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+	b.oldLayout = oldL;
+	b.newLayout = newL;
+	b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+	b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+	b.image = g_vkVramImage;
+	b.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	b.subresourceRange.levelCount = 1;
+	b.subresourceRange.layerCount = 1;
+	b.srcAccessMask = srcA;
+	b.dstAccessMask = dstA;
+	vkCmdPipelineBarrier(cb, srcStage, dstStage, 0, 0, nullptr, 0, nullptr, 1, &b);
+}
+
+void TransitionVramToShaderRead(VkCommandBuffer cb)
+{
+	// Copy staging buffer -> VRAM image, leaving image in SHADER_READ_ONLY_OPTIMAL.
+	VramImageBarrier(cb,
+		VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		0, VK_ACCESS_TRANSFER_WRITE_BIT,
+		VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+
+	VkBufferImageCopy r = {};
+	r.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	r.imageSubresource.layerCount = 1;
+	r.imageExtent = { VRAM_WIDTH, VRAM_HEIGHT, 1 };
+	vkCmdCopyBufferToImage(cb, g_vkVramStaging, g_vkVramImage,
+		VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &r);
+
+	VramImageBarrier(cb,
+		VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+		VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT,
+		VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+}
+
+bool CreateBasicGraphicsPipeline()
+{
+	g_vkVertModule = CompileGLSL(kBasicVertSrc, shaderc_vertex_shader,   "psx_basic.vert");
+	g_vkFragModule = CompileGLSL(kBasicFragSrc, shaderc_fragment_shader, "psx_basic.frag");
+	if (!g_vkVertModule || !g_vkFragModule) {
+		eprinterr("Failed to compile basic GLSL shaders\n");
+		return false;
+	}
+
+	// Pipeline layout — push constants for projection + descriptor set 0
+	// for the VRAM combined-image-sampler used by the fragment shader.
+	VkPushConstantRange pcRange = {};
+	pcRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+	pcRange.offset = 0;
+	pcRange.size = sizeof(PushBlock);
+
+	VkPipelineLayoutCreateInfo plci = {};
+	plci.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+	plci.setLayoutCount = 1;
+	plci.pSetLayouts = &g_vkDescSetLayout;
+	plci.pushConstantRangeCount = 1;
+	plci.pPushConstantRanges = &pcRange;
+	VK_CHECK(vkCreatePipelineLayout(g_vkDevice, &plci, nullptr, &g_vkPipelineLayout));
+
+	// Vertex input — match GrVertex with PGXP (USE_PGXP=1):
+	//   loc 0 (a_position) : 4×float  (x, y, page, clut)
+	//   loc 1 (a_zw)       : 4×float  (z, scr_h, ofsX, ofsY)
+	//   loc 2 (a_texcoord) : 4×u8 raw 0..255 (u, v, bright, dither)
+	//   loc 3 (a_color)    : 4×u8 normalised (r, g, b, a)
+	//   loc 4 (a_extra)    : 4×i8 raw -128..127 (tcx, tcy, _p0, _p1)
+	VkVertexInputBindingDescription vibind = {};
+	vibind.binding = 0;
+	vibind.stride = sizeof(GrVertex);
+	vibind.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+
+	VkVertexInputAttributeDescription viattr[5] = {};
+	viattr[0].location = 0; viattr[0].binding = 0;
+	viattr[0].format = VK_FORMAT_R32G32B32A32_SFLOAT;
+	viattr[0].offset = offsetof(GrVertex, x);
+	viattr[1].location = 1; viattr[1].binding = 0;
+	viattr[1].format = VK_FORMAT_R32G32B32A32_SFLOAT;
+	viattr[1].offset = offsetof(GrVertex, z);
+	viattr[2].location = 2; viattr[2].binding = 0;
+	viattr[2].format = VK_FORMAT_R8G8B8A8_USCALED;	// raw 0..255 as float
+	viattr[2].offset = offsetof(GrVertex, u);
+	viattr[3].location = 3; viattr[3].binding = 0;
+	viattr[3].format = VK_FORMAT_R8G8B8A8_UNORM;	// 0..1
+	viattr[3].offset = offsetof(GrVertex, r);
+	viattr[4].location = 4; viattr[4].binding = 0;
+	viattr[4].format = VK_FORMAT_R8G8B8A8_SSCALED;	// raw -128..127 as float
+	viattr[4].offset = offsetof(GrVertex, tcx);
+
+	VkPipelineVertexInputStateCreateInfo vi = {};
+	vi.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+	vi.vertexBindingDescriptionCount = 1;
+	vi.pVertexBindingDescriptions = &vibind;
+	vi.vertexAttributeDescriptionCount = 5;
+	vi.pVertexAttributeDescriptions = viattr;
+
+	VkPipelineInputAssemblyStateCreateInfo ia = {};
+	ia.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+	ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+	VkPipelineViewportStateCreateInfo vp = {};
+	vp.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+	vp.viewportCount = 1;
+	vp.scissorCount  = 1;
+
+	VkPipelineRasterizationStateCreateInfo rs = {};
+	rs.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+	rs.polygonMode = VK_POLYGON_MODE_FILL;
+	rs.cullMode = VK_CULL_MODE_NONE;
+	rs.lineWidth = 1.0f;
+
+	VkPipelineMultisampleStateCreateInfo ms = {};
+	ms.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+	ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+	// Two depth-stencil states: opaque (BM_NONE) writes depth, every blend
+	// mode reads depth but does NOT write it (mirrors GR_EnableDepth(0)
+	// that the GL backend issues whenever the blend mode is non-NONE —
+	// keeps semi-trans polygons from punching holes in opaque ones in
+	// the depth buffer).
+	VkPipelineDepthStencilStateCreateInfo dsOpaque = {};
+	dsOpaque.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+	dsOpaque.depthTestEnable = VK_TRUE;
+	dsOpaque.depthWriteEnable = VK_TRUE;
+	dsOpaque.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
+
+	VkPipelineDepthStencilStateCreateInfo dsBlend = dsOpaque;
+	dsBlend.depthWriteEnable = VK_FALSE;
+
+	// PSX blend modes — see GP0 ABR field. Mirror exactly what the GL
+	// backend does in GR_SetBlendMode (PsyX_render.cpp) so semi-trans
+	// polys with alpha=1.0 stay opaque (no transparency) and only the
+	// STP-bit texels (output alpha=0.5 from the fragment) actually blend.
+	auto blendForMode = [](int mode) {
+		VkPipelineColorBlendAttachmentState a = {};
+		a.colorWriteMask = VK_COLOR_COMPONENT_R_BIT|VK_COLOR_COMPONENT_G_BIT|
+		                   VK_COLOR_COMPONENT_B_BIT|VK_COLOR_COMPONENT_A_BIT;
+		switch (mode) {
+		case BM_NONE:
+			a.blendEnable = VK_FALSE;
+			break;
+		case BM_AVERAGE:	// glBlendFunc(SRC_ALPHA, ONE_MINUS_SRC_ALPHA)
+			a.blendEnable = VK_TRUE;
+			a.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+			a.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+			a.colorBlendOp = VK_BLEND_OP_ADD;
+			a.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+			a.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+			a.alphaBlendOp = VK_BLEND_OP_ADD;
+			break;
+		case BM_ADD:		// glBlendFunc(ONE, ONE)
+			a.blendEnable = VK_TRUE;
+			a.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
+			a.dstColorBlendFactor = VK_BLEND_FACTOR_ONE;
+			a.colorBlendOp = VK_BLEND_OP_ADD;
+			a.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+			a.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+			a.alphaBlendOp = VK_BLEND_OP_ADD;
+			break;
+		case BM_SUBTRACT:	// glBlendEq REVERSE_SUBTRACT, glBlendFunc(ONE, ONE)
+			a.blendEnable = VK_TRUE;
+			a.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
+			a.dstColorBlendFactor = VK_BLEND_FACTOR_ONE;
+			a.colorBlendOp = VK_BLEND_OP_REVERSE_SUBTRACT;
+			a.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+			a.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+			a.alphaBlendOp = VK_BLEND_OP_ADD;
+			break;
+		case BM_ADD_QUATER_SOURCE:	// glBlendFunc(CONSTANT_ALPHA=0.25, ONE)
+			a.blendEnable = VK_TRUE;
+			a.srcColorBlendFactor = VK_BLEND_FACTOR_CONSTANT_ALPHA;
+			a.dstColorBlendFactor = VK_BLEND_FACTOR_ONE;
+			a.colorBlendOp = VK_BLEND_OP_ADD;
+			a.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+			a.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+			a.alphaBlendOp = VK_BLEND_OP_ADD;
+			break;
+		}
+		return a;
+	};
+
+	VkPipelineColorBlendAttachmentState cbaArr[5];
+	VkPipelineColorBlendStateCreateInfo cbArr[5] = {};
+	for (int i = 0; i < 5; ++i) {
+		cbaArr[i] = blendForMode(i);
+		cbArr[i].sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+		cbArr[i].attachmentCount = 1;
+		cbArr[i].pAttachments = &cbaArr[i];
+	}
+
+	VkDynamicState dynStates[] = {
+		VK_DYNAMIC_STATE_VIEWPORT,
+		VK_DYNAMIC_STATE_SCISSOR,
+		VK_DYNAMIC_STATE_BLEND_CONSTANTS,
+	};
+	VkPipelineDynamicStateCreateInfo dyn = {};
+	dyn.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+	dyn.dynamicStateCount = 3;
+	dyn.pDynamicStates = dynStates;
+
+	VkPipelineShaderStageCreateInfo stages[2] = {};
+	stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+	stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
+	stages[0].module = g_vkVertModule;
+	stages[0].pName = "main";
+	stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+	stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+	stages[1].module = g_vkFragModule;
+	stages[1].pName = "main";
+
+	VkGraphicsPipelineCreateInfo gpci = {};
+	gpci.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+	gpci.stageCount = 2;
+	gpci.pStages = stages;
+	gpci.pVertexInputState = &vi;
+	gpci.pInputAssemblyState = &ia;
+	gpci.pViewportState = &vp;
+	gpci.pRasterizationState = &rs;
+	gpci.pMultisampleState = &ms;
+	gpci.pDynamicState = &dyn;
+	gpci.layout = g_vkPipelineLayout;
+	gpci.renderPass = g_vkClearRenderPass;
+	gpci.subpass = 0;
+
+	// Build one PSO per blend mode — same vertex/fragment, the colour-
+	// blend state and depth-write change. GR_SetBlendMode picks the
+	// right index, GR_DrawTriangles re-binds when it changes.
+	bool ok = true;
+	for (int i = 0; i < 5; ++i) {
+		gpci.pColorBlendState = &cbArr[i];
+		gpci.pDepthStencilState = (i == BM_NONE) ? &dsOpaque : &dsBlend;
+		VK_CHECK(vkCreateGraphicsPipelines(g_vkDevice, VK_NULL_HANDLE, 1, &gpci, nullptr, &g_vkPipelines[i]));
+		if (g_vkPipelines[i] == VK_NULL_HANDLE) ok = false;
+	}
+	return ok;
+}
+
+bool CreateVertexBuffer()
+{
+	const VkDeviceSize totalBytes = (VkDeviceSize)sizeof(GrVertex) * MAX_VERTEX_BUFFER_SIZE;
+	if (!CreateBuffer(totalBytes,
+		VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+		VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+		&g_vkVertexBuffer, &g_vkVertexBufferMem)) {
+		return false;
+	}
+	VK_CHECK(vkMapMemory(g_vkDevice, g_vkVertexBufferMem, 0, VK_WHOLE_SIZE, 0, &g_vkVertexBufferMap));
+	return true;
+}
+
+void DestroySwapchainObjects()
+{
+	if (g_vkDevice == VK_NULL_HANDLE) return;
+	vkDeviceWaitIdle(g_vkDevice);
+	for (auto fb : g_vkFramebuffers)
+		if (fb) vkDestroyFramebuffer(g_vkDevice, fb, nullptr);
+	g_vkFramebuffers.clear();
+	for (auto v : g_vkSwapchainImageViews)
+		if (v) vkDestroyImageView(g_vkDevice, v, nullptr);
+	g_vkSwapchainImageViews.clear();
+	g_vkSwapchainImages.clear();
+	if (g_vkSwapchain) {
+		vkDestroySwapchainKHR(g_vkDevice, g_vkSwapchain, nullptr);
+		g_vkSwapchain = VK_NULL_HANDLE;
+	}
+}
+
+} // anonymous namespace
+
+// =======================================================================
+// Public GR_* API
+// =======================================================================
+
+int GR_InitialiseRender(char* windowName, int width, int height, int fullscreen)
+{
+	g_windowWidth  = width;
+	g_windowHeight = height;
+
+	int windowFlags = SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE;
+	if (fullscreen)
+		windowFlags |= SDL_WINDOW_FULLSCREEN;
+
+	g_window = SDL_CreateWindow(windowName,
+		SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+		width, height, windowFlags);
+	if (!g_window) {
+		eprinterr("SDL_CreateWindow (Vulkan) failed: %s\n", SDL_GetError());
+		return 0;
+	}
+
+	uint32_t extCount = 0;
+	if (!SDL_Vulkan_GetInstanceExtensions(g_window, &extCount, nullptr)) {
+		eprinterr("SDL_Vulkan_GetInstanceExtensions: %s\n", SDL_GetError());
+		return 0;
+	}
+	std::vector<const char*> exts(extCount);
+	SDL_Vulkan_GetInstanceExtensions(g_window, &extCount, exts.data());
+#if defined(__APPLE__)
+	exts.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+	exts.push_back("VK_KHR_get_physical_device_properties2");
+#endif
+
+	VkApplicationInfo app = {};
+	app.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+	app.pApplicationName = windowName ? windowName : "PsyX";
+	app.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
+	app.pEngineName = "PsyX-Vulkan";
+	app.engineVersion = VK_MAKE_VERSION(1, 0, 0);
+	app.apiVersion = VK_API_VERSION_1_1;
+
+	VkInstanceCreateInfo ici = {};
+	ici.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+	ici.pApplicationInfo = &app;
+	ici.enabledExtensionCount = (uint32_t)exts.size();
+	ici.ppEnabledExtensionNames = exts.data();
+#if defined(__APPLE__)
+	ici.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+#endif
+	VK_CHECK(vkCreateInstance(&ici, nullptr, &g_vkInstance));
+	if (g_vkInstance == VK_NULL_HANDLE) {
+		eprinterr("vkCreateInstance failed (MoltenVK ICD missing or broken?)\n");
+		return 0;
+	}
+
+	if (!SDL_Vulkan_CreateSurface(g_window, g_vkInstance, &g_vkSurface)) {
+		eprinterr("SDL_Vulkan_CreateSurface: %s\n", SDL_GetError());
+		return 0;
+	}
+
+	if (!PickPhysicalDeviceAndQueueFamilies()) return 0;
+	if (!CreateLogicalDevice())                return 0;
+	if (!CreateSwapchain(width, height))       return 0;
+	if (!CreateDepthBuffer())                  return 0;
+	if (!CreateClearRenderPass())              return 0;
+	if (!CreateFramebuffers())                 return 0;
+	if (!CreateCommandPoolAndBuffers())        return 0;
+	if (!CreateSyncObjects())                  return 0;
+
+	g_shadercCompiler = shaderc_compiler_initialize();
+	if (!g_shadercCompiler) {
+		eprinterr("shaderc_compiler_initialize failed\n");
+		return 0;
+	}
+
+	// VRAM image + sampler + descriptor set must exist BEFORE the
+	// pipeline layout (which references the descriptor set layout).
+	if (!CreateVramImage())             return 0;
+	if (!CreateDescriptorSet())         return 0;
+	if (!CreateBasicGraphicsPipeline()) return 0;
+	if (!CreateVertexBuffer())          return 0;
+
+	// First-time transition: take the brand-new VRAM image (UNDEFINED)
+	// to SHADER_READ_ONLY so the very first frame has a valid layout
+	// even before any upload happens.
+	{
+		VkCommandBufferAllocateInfo ai = {};
+		ai.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+		ai.commandPool = g_vkCommandPool;
+		ai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+		ai.commandBufferCount = 1;
+		VkCommandBuffer cb;
+		vkAllocateCommandBuffers(g_vkDevice, &ai, &cb);
+		VkCommandBufferBeginInfo bi = {};
+		bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+		bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+		vkBeginCommandBuffer(cb, &bi);
+		VramImageBarrier(cb,
+			VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+			0, VK_ACCESS_SHADER_READ_BIT,
+			VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+		vkEndCommandBuffer(cb);
+		VkSubmitInfo si = {};
+		si.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+		si.commandBufferCount = 1;
+		si.pCommandBuffers = &cb;
+		vkQueueSubmit(g_vkGraphicsQueue, 1, &si, VK_NULL_HANDLE);
+		vkQueueWaitIdle(g_vkGraphicsQueue);
+		vkFreeCommandBuffers(g_vkDevice, g_vkCommandPool, 1, &cb);
+	}
+
+	eprintinfo("Vulkan/MoltenVK backend initialised: %dx%d, swap images=%zu\n",
+		(int)g_vkSwapchainExtent.width, (int)g_vkSwapchainExtent.height,
+		g_vkSwapchainImages.size());
+	return 1;
+}
+
+int GR_InitialisePSX()
+{
+	// Equivalent of the GL backend's PSX-shader / VRAM-texture init.
+	// Most of this is folded into GR_InitialiseRender for now.
+	return 1;
+}
+
+void GR_Shutdown()
+{
+	if (g_vkDevice != VK_NULL_HANDLE)
+		vkDeviceWaitIdle(g_vkDevice);
+
+	if (g_shadercCompiler) {
+		shaderc_compiler_release(g_shadercCompiler);
+		g_shadercCompiler = nullptr;
+	}
+
+	if (g_vkVertexBufferMap)  { vkUnmapMemory(g_vkDevice, g_vkVertexBufferMem); g_vkVertexBufferMap = nullptr; }
+	if (g_vkVertexBuffer)     { vkDestroyBuffer(g_vkDevice, g_vkVertexBuffer, nullptr);     g_vkVertexBuffer = VK_NULL_HANDLE; }
+	if (g_vkVertexBufferMem)  { vkFreeMemory(g_vkDevice, g_vkVertexBufferMem, nullptr);     g_vkVertexBufferMem = VK_NULL_HANDLE; }
+
+	if (g_vkDepthImageView)   { vkDestroyImageView(g_vkDevice, g_vkDepthImageView, nullptr); g_vkDepthImageView = VK_NULL_HANDLE; }
+	if (g_vkDepthImage)       { vkDestroyImage(g_vkDevice, g_vkDepthImage, nullptr); g_vkDepthImage = VK_NULL_HANDLE; }
+	if (g_vkDepthImageMem)    { vkFreeMemory(g_vkDevice, g_vkDepthImageMem, nullptr); g_vkDepthImageMem = VK_NULL_HANDLE; }
+
+	if (g_vkVramStagingMap)   { vkUnmapMemory(g_vkDevice, g_vkVramStagingMem); g_vkVramStagingMap = nullptr; }
+	if (g_vkVramStaging)      { vkDestroyBuffer(g_vkDevice, g_vkVramStaging, nullptr); g_vkVramStaging = VK_NULL_HANDLE; }
+	if (g_vkVramStagingMem)   { vkFreeMemory(g_vkDevice, g_vkVramStagingMem, nullptr); g_vkVramStagingMem = VK_NULL_HANDLE; }
+	if (g_vkVramSampler)      { vkDestroySampler(g_vkDevice, g_vkVramSampler, nullptr); g_vkVramSampler = VK_NULL_HANDLE; }
+	if (g_vkVramImageView)    { vkDestroyImageView(g_vkDevice, g_vkVramImageView, nullptr); g_vkVramImageView = VK_NULL_HANDLE; }
+	if (g_vkVramImage)        { vkDestroyImage(g_vkDevice, g_vkVramImage, nullptr); g_vkVramImage = VK_NULL_HANDLE; }
+	if (g_vkVramImageMem)     { vkFreeMemory(g_vkDevice, g_vkVramImageMem, nullptr); g_vkVramImageMem = VK_NULL_HANDLE; }
+
+	if (g_vkDescPool)         { vkDestroyDescriptorPool(g_vkDevice, g_vkDescPool, nullptr); g_vkDescPool = VK_NULL_HANDLE; }
+	if (g_vkDescSetLayout)    { vkDestroyDescriptorSetLayout(g_vkDevice, g_vkDescSetLayout, nullptr); g_vkDescSetLayout = VK_NULL_HANDLE; }
+
+	for (int i = 0; i < 5; ++i) {
+		if (g_vkPipelines[i]) { vkDestroyPipeline(g_vkDevice, g_vkPipelines[i], nullptr); g_vkPipelines[i] = VK_NULL_HANDLE; }
+	}
+	if (g_vkPipelineLayout)   { vkDestroyPipelineLayout(g_vkDevice, g_vkPipelineLayout, nullptr); g_vkPipelineLayout = VK_NULL_HANDLE; }
+	if (g_vkVertModule)       { vkDestroyShaderModule(g_vkDevice, g_vkVertModule, nullptr); g_vkVertModule = VK_NULL_HANDLE; }
+	if (g_vkFragModule)       { vkDestroyShaderModule(g_vkDevice, g_vkFragModule, nullptr); g_vkFragModule = VK_NULL_HANDLE; }
+
+	for (int i = 0; i < kMaxFramesInFlight; ++i) {
+		if (g_vkImageAvailableSems[i]) vkDestroySemaphore(g_vkDevice, g_vkImageAvailableSems[i], nullptr);
+		if (g_vkRenderFinishedSems[i]) vkDestroySemaphore(g_vkDevice, g_vkRenderFinishedSems[i], nullptr);
+		if (g_vkInFlightFences[i])     vkDestroyFence(g_vkDevice, g_vkInFlightFences[i], nullptr);
+	}
+	if (g_vkCommandPool)     vkDestroyCommandPool(g_vkDevice, g_vkCommandPool, nullptr);
+	DestroySwapchainObjects();
+	if (g_vkClearRenderPass) vkDestroyRenderPass(g_vkDevice, g_vkClearRenderPass, nullptr);
+	if (g_vkDevice)          vkDestroyDevice(g_vkDevice, nullptr);
+	if (g_vkSurface)         vkDestroySurfaceKHR(g_vkInstance, g_vkSurface, nullptr);
+	if (g_vkInstance)        vkDestroyInstance(g_vkInstance, nullptr);
+
+	g_vkInstance = VK_NULL_HANDLE;
+	g_vkDevice = VK_NULL_HANDLE;
+	g_vkSurface = VK_NULL_HANDLE;
+	g_vkClearRenderPass = VK_NULL_HANDLE;
+	g_vkCommandPool = VK_NULL_HANDLE;
+}
+
+void GR_ResetDevice() {}
+void GR_UpdateSwapIntervalState(int /*swapInterval*/) {}
+
+// -----------------------------------------------------------------------
+// Per-frame: BeginScene records, EndScene submits + presents.
+// -----------------------------------------------------------------------
+
+void GR_BeginScene()
+{
+	if (g_vkSceneRecording) return;
+
+	vkWaitForFences(g_vkDevice, 1, &g_vkInFlightFences[g_vkCurrentFrame], VK_TRUE, UINT64_MAX);
+
+	VkResult ar = vkAcquireNextImageKHR(g_vkDevice, g_vkSwapchain, UINT64_MAX,
+		g_vkImageAvailableSems[g_vkCurrentFrame], VK_NULL_HANDLE,
+		&g_vkAcquiredImageIdx);
+	if (ar == VK_ERROR_OUT_OF_DATE_KHR) {
+		DestroySwapchainObjects();
+		CreateSwapchain(g_windowWidth, g_windowHeight);
+		CreateFramebuffers();
+		return;
+	}
+
+	vkResetFences(g_vkDevice, 1, &g_vkInFlightFences[g_vkCurrentFrame]);
+
+	VkCommandBuffer cb = g_vkCmdBuffers[g_vkCurrentFrame];
+	vkResetCommandBuffer(cb, 0);
+
+	VkCommandBufferBeginInfo bi = {};
+	bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+	vkBeginCommandBuffer(cb, &bi);
+
+	// Upload CPU-side VRAM mirror to the GPU image if dirty. Done OUTSIDE
+	// the render pass — vkCmdCopyBufferToImage and image-layout barriers
+	// are not allowed inside one.
+	if (g_vkVramDirty) {
+		// Refresh the staging buffer from the CPU mirror.
+		memcpy(g_vkVramStagingMap, g_vkVramCPU, sizeof(g_vkVramCPU));
+
+		// SHADER_READ_ONLY → TRANSFER_DST → copy → SHADER_READ_ONLY
+		VramImageBarrier(cb,
+			VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+			VK_ACCESS_SHADER_READ_BIT, VK_ACCESS_TRANSFER_WRITE_BIT,
+			VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+
+		VkBufferImageCopy r = {};
+		r.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		r.imageSubresource.layerCount = 1;
+		r.imageExtent = { VRAM_WIDTH, VRAM_HEIGHT, 1 };
+		vkCmdCopyBufferToImage(cb, g_vkVramStaging, g_vkVramImage,
+			VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &r);
+
+		VramImageBarrier(cb,
+			VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+			VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT,
+			VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+
+		g_vkVramDirty = false;
+	}
+
+	VkClearValue cv[2] = {};
+	cv[0].color = { { g_vkClearColor[0], g_vkClearColor[1], g_vkClearColor[2], g_vkClearColor[3] } };
+	cv[1].depthStencil = { 1.0f, 0 };
+
+	VkRenderPassBeginInfo rpb = {};
+	rpb.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+	rpb.renderPass = g_vkClearRenderPass;
+	rpb.framebuffer = g_vkFramebuffers[g_vkAcquiredImageIdx];
+	rpb.renderArea.offset = { 0, 0 };
+	rpb.renderArea.extent = g_vkSwapchainExtent;
+	rpb.clearValueCount = 2;
+	rpb.pClearValues = cv;
+	vkCmdBeginRenderPass(cb, &rpb, VK_SUBPASS_CONTENTS_INLINE);
+
+	// Default viewport + scissor cover the whole swapchain. The Y axis is
+	// flipped (negative height) so vertices coming out of GR_Ortho2D /
+	// GR_Perspective3D — which are written for the GL backend's clip
+	// space (Y-up) — still rasterise the right way up under Vulkan's
+	// Y-down clip space. Requires VK_KHR_maintenance1, in core since 1.1.
+	VkViewport vp = {};
+	vp.x = 0.0f;
+	vp.y = (float)g_vkSwapchainExtent.height;
+	vp.width  =  (float)g_vkSwapchainExtent.width;
+	vp.height = -(float)g_vkSwapchainExtent.height;
+	vp.minDepth = 0.0f; vp.maxDepth = 1.0f;
+	vkCmdSetViewport(cb, 0, 1, &vp);
+
+	VkRect2D sc = { {0,0}, g_vkSwapchainExtent };
+	vkCmdSetScissor(cb, 0, 1, &sc);
+
+	// Bind initial blend-mode pipeline + vertex buffer + descriptor set.
+	// GR_DrawTriangles will rebind a different pipeline if the engine
+	// switches blend modes mid-frame.
+	g_vkBoundPipelineIdx = BM_NONE;
+	vkCmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, g_vkPipelines[BM_NONE]);
+	VkDeviceSize zero = 0;
+	vkCmdBindVertexBuffers(cb, 0, 1, &g_vkVertexBuffer, &zero);
+	vkCmdBindDescriptorSets(cb, VK_PIPELINE_BIND_POINT_GRAPHICS,
+		g_vkPipelineLayout, 0, 1, &g_vkDescSet, 0, nullptr);
+
+	// PSX BM_AVERAGE = 0.5*src + 0.5*dst. Set Vulkan blend constant to
+	// 0.5 so the BM_AVERAGE pipeline (CONSTANT_COLOR factor) gets it.
+	float blendConsts[4] = { 0.5f, 0.5f, 0.5f, 0.25f };
+	vkCmdSetBlendConstants(cb, blendConsts);
+
+	g_vkSceneRecording = true;
+}
+
+void GR_EndScene()
+{
+	if (!g_vkSceneRecording) return;
+
+	VkCommandBuffer cb = g_vkCmdBuffers[g_vkCurrentFrame];
+	vkCmdEndRenderPass(cb);
+	vkEndCommandBuffer(cb);
+
+	VkPipelineStageFlags waitStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+	VkSubmitInfo si = {};
+	si.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+	si.waitSemaphoreCount = 1;
+	si.pWaitSemaphores = &g_vkImageAvailableSems[g_vkCurrentFrame];
+	si.pWaitDstStageMask = &waitStage;
+	si.commandBufferCount = 1;
+	si.pCommandBuffers = &cb;
+	si.signalSemaphoreCount = 1;
+	si.pSignalSemaphores = &g_vkRenderFinishedSems[g_vkCurrentFrame];
+	VK_CHECK(vkQueueSubmit(g_vkGraphicsQueue, 1, &si, g_vkInFlightFences[g_vkCurrentFrame]));
+
+	VkPresentInfoKHR pi = {};
+	pi.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+	pi.waitSemaphoreCount = 1;
+	pi.pWaitSemaphores = &g_vkRenderFinishedSems[g_vkCurrentFrame];
+	pi.swapchainCount = 1;
+	pi.pSwapchains = &g_vkSwapchain;
+	pi.pImageIndices = &g_vkAcquiredImageIdx;
+	VkResult pr = vkQueuePresentKHR(g_vkPresentQueue, &pi);
+	if (pr == VK_ERROR_OUT_OF_DATE_KHR || pr == VK_SUBOPTIMAL_KHR) {
+		DestroySwapchainObjects();
+		CreateSwapchain(g_windowWidth, g_windowHeight);
+		CreateFramebuffers();
+	}
+
+	g_vkCurrentFrame = (g_vkCurrentFrame + 1) % kMaxFramesInFlight;
+	g_vkSceneRecording = false;
+}
+
+void GR_SwapWindow() { /* present already happened in GR_EndScene */ }
+
+// -----------------------------------------------------------------------
+// Clears
+// -----------------------------------------------------------------------
+
+void GR_Clear(int /*x*/, int /*y*/, int /*w*/, int /*h*/,
+	unsigned char r, unsigned char g, unsigned char b)
+{
+	g_vkClearColor[0] = (float)r / 255.0f;
+	g_vkClearColor[1] = (float)g / 255.0f;
+	g_vkClearColor[2] = (float)b / 255.0f;
+	g_vkClearColor[3] = 1.0f;
+}
+
+void GR_ClearVRAM(int, int, int, int, unsigned char, unsigned char, unsigned char) {}
+
+// -----------------------------------------------------------------------
+// Vertex buffer + draw
+// -----------------------------------------------------------------------
+
+void GR_UpdateVertexBuffer(const GrVertex* vertices, int count)
+{
+	if (!vertices || count <= 0 || !g_vkVertexBufferMap) return;
+	if (count > MAX_VERTEX_BUFFER_SIZE) count = MAX_VERTEX_BUFFER_SIZE;
+	memcpy(g_vkVertexBufferMap, vertices, sizeof(GrVertex) * (size_t)count);
+	g_vkVertexBufferSize = (uint32_t)count;
+
+	// DEBUG: dump first 3 vertices once per ~120 frames — but only when
+	// the buffer has more than 30 vertices (skips the FMV's 6-vertex
+	// underlay quad so we get real engine geometry samples).
+	static int s_dumpTick = 0;
+	if (++s_dumpTick >= 120 && count >= 30) {
+		s_dumpTick = 0;
+		for (int i = 0; i < 3 && i < count; ++i) {
+			const GrVertex& v = vertices[i];
+#if USE_PGXP
+			eprintinfo("[VK][V%d] pos=(%.3f,%.3f) page=%.3f clut=%.3f  "
+				"zw=(%.3f,%.3f,%.3f,%.3f)  "
+				"uv=(%u,%u) bright=%u dither=%u  "
+				"rgba=(%u,%u,%u,%u)  "
+				"tcx=(%d,%d)\n",
+				i, (double)v.x, (double)v.y, (double)v.page, (double)v.clut,
+				(double)v.z, (double)v.scr_h, (double)v.ofsX, (double)v.ofsY,
+				(unsigned)v.u, (unsigned)v.v, (unsigned)v.bright, (unsigned)v.dither,
+				(unsigned)v.r, (unsigned)v.g, (unsigned)v.b, (unsigned)v.a,
+				(int)v.tcx, (int)v.tcy);
+#else
+			eprintinfo("[VK][V%d] pos=(%d,%d) page=%d clut=%d  "
+				"uv=(%u,%u) bright=%u dither=%u  "
+				"rgba=(%u,%u,%u,%u)\n",
+				i, (int)v.x, (int)v.y, (int)v.page, (int)v.clut,
+				(unsigned)v.u, (unsigned)v.v, (unsigned)v.bright, (unsigned)v.dither,
+				(unsigned)v.r, (unsigned)v.g, (unsigned)v.b, (unsigned)v.a);
+#endif
+		}
+	}
+}
+
+void GR_DrawTriangles(int start_vertex, int triangles)
+{
+	// DEBUG counter — prints draws-per-second. Lets us tell at a glance
+	// whether the engine is actually pumping vkCmdDraw at all.
+	static uint64_t s_drawsSinceLog = 0;
+	static uint64_t s_trisSinceLog  = 0;
+	static int s_logTickFrame = 0;
+	s_drawsSinceLog++;
+	s_trisSinceLog += (uint64_t)(triangles > 0 ? triangles : 0);
+
+	if (!g_vkSceneRecording || triangles <= 0) return;
+	VkCommandBuffer cb = g_vkCmdBuffers[g_vkCurrentFrame];
+
+	// Switch pipeline if blend mode changed since last draw.
+	if (g_vkActiveBlendMode != g_vkBoundPipelineIdx) {
+		const int idx = (g_vkActiveBlendMode >= 0 && g_vkActiveBlendMode < 5)
+			? g_vkActiveBlendMode : 0;
+		vkCmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, g_vkPipelines[idx]);
+		g_vkBoundPipelineIdx = idx;
+	}
+
+	vkCmdPushConstants(cb, g_vkPipelineLayout,
+		VK_SHADER_STAGE_VERTEX_BIT,
+		0, sizeof(PushBlock), &g_vkPushBlock);
+
+	vkCmdDraw(cb, (uint32_t)(triangles * 3), 1, (uint32_t)start_vertex, 0);
+
+	if (++s_logTickFrame >= 60) {
+		eprintinfo("[VK] draws/s=%llu tris/s=%llu vbufVerts=%u\n",
+			(unsigned long long)s_drawsSinceLog,
+			(unsigned long long)s_trisSinceLog,
+			g_vkVertexBufferSize);
+		s_drawsSinceLog = s_trisSinceLog = 0;
+		s_logTickFrame = 0;
+	}
+}
+
+// -----------------------------------------------------------------------
+// Projection helpers — fill push-constant matrix used by the basic shader.
+// PSX coordinate space is Y-down; the engine already feeds the renderer in
+// pixel coords mapped via the projection matrix below.
+// -----------------------------------------------------------------------
+
+// Match the GL backend's matrices exactly. Y-flip (GL→Vulkan clip-space)
+// is done via a negative-height viewport (VK_KHR_maintenance1 / VK 1.1
+// core), so the matrices themselves stay identical to the GL ones.
+
+void GR_Ortho2D(float left, float right, float bottom, float top, float znear, float zfar)
+{
+	float a = 2.0f / (right - left);
+	float b = 2.0f / (top - bottom);
+	float c = 2.0f / (znear - zfar);
+	float x = (left + right) / (left - right);
+	float y = (bottom + top) / (bottom - top);
+	float z = (znear + zfar) / (znear - zfar);
+	float* m = g_vkPushBlock.Projection;
+	m[0]  = a; m[1]  = 0; m[2]  = 0; m[3]  = 0;
+	m[4]  = 0; m[5]  = b; m[6]  = 0; m[7]  = 0;
+	m[8]  = 0; m[9]  = 0; m[10] = c; m[11] = 0;
+	m[12] = x; m[13] = y; m[14] = z; m[15] = 1;
+}
+
+#include <math.h>
+void GR_Perspective3D(const float fov, const float width, const float height,
+                      const float zNear, const float zFar)
+{
+	const float sinF = sinf(0.5f * fov);
+	const float cosF = cosf(0.5f * fov);
+	const float h = cosF / sinF;
+	const float w = (h * height) / width;
+	float* m = g_vkPushBlock.Projection3D;
+	m[0]  = w; m[1]  = 0; m[2]  = 0;                                m[3]  = 0;
+	m[4]  = 0; m[5]  = h; m[6]  = 0;                                m[7]  = 0;
+	m[8]  = 0; m[9]  = 0; m[10] = (zFar + zNear) / (zFar - zNear); m[11] = 1;
+	m[12] = 0; m[13] = 0; m[14] = -(2*zFar*zNear) / (zFar - zNear); m[15] = 0;
+}
+
+// -----------------------------------------------------------------------
+// Stubs — to be filled in subsequent revisions
+// -----------------------------------------------------------------------
+
+void GR_SaveVRAM(const char*, int, int, int, int, int) {}
+
+void GR_CopyVRAM(unsigned short* src, int x, int y, int w, int h, int dst_x, int dst_y)
+{
+	g_vkVramDirty = true;
+	int stride = w;
+	if (!src) {
+		src = g_vkVramCPU;
+		stride = VRAM_WIDTH;
+	}
+	src += x + y * stride;
+	unsigned short* dst = g_vkVramCPU + dst_x + dst_y * VRAM_WIDTH;
+	for (int row = 0; row < h; ++row) {
+		memcpy(dst, src, w * sizeof(unsigned short));
+		dst += VRAM_WIDTH;
+		src += stride;
+	}
+
+	// DEBUG: count uploads + sample one pixel so we can see if data flows.
+	static int s_uploads = 0;
+	static int s_logTick = 0;
+	s_uploads++;
+	if (++s_logTick >= 20) {
+		s_logTick = 0;
+		// pick the centre of the just-copied region
+		int cx = dst_x + w/2;
+		int cy = dst_y + h/2;
+		unsigned short v = g_vkVramCPU[cy * VRAM_WIDTH + cx];
+		eprintinfo("[VK][VRAM] upload #%d → (%d,%d) %dx%d  centre[%d,%d]=0x%04x\n",
+			s_uploads, dst_x, dst_y, w, h, cx, cy, (unsigned)v);
+	}
+}
+
+void GR_ReadVRAM(unsigned short* dst, int x, int y, int dst_w, int dst_h)
+{
+	const unsigned short* src = g_vkVramCPU + x + y * VRAM_WIDTH;
+	for (int row = 0; row < dst_h; ++row) {
+		memcpy(dst, src, dst_w * sizeof(unsigned short));
+		dst += dst_w;
+		src += VRAM_WIDTH;
+	}
+}
+
+void GR_UpdateVRAM()
+{
+	// CPU mirror is already up-to-date — just flag the GPU image dirty
+	// so BeginScene re-uploads on the next frame.
+	g_vkVramDirty = true;
+}
+
+void GR_StoreFrameBuffer(int, int, int, int) {
+	// Capturing the just-rendered framebuffer back into VRAM (used by
+	// some PSX scratch effects) needs an extra image-to-image copy.
+	// Stubbed for now — visual artefact: certain post-process effects
+	// won't appear, but base rendering proceeds.
+}
+void GR_ReadFramebufferDataToVRAM() {}
+
+TextureID GR_CreateRGBATexture(int /*w*/, int /*h*/, unsigned char* /*data*/) { return 0; }
+
+// GR_Shader_Compile is meaningful but the engine treats the returned ID as
+// opaque; for now we return 0 so the engine's "is there a shader?" checks
+// pass. Real shader caching/binding will be added with the GTE port.
+ShaderID GR_Shader_Compile(const char* /*src*/) { return 0; }
+
+void GR_SetShader(const ShaderID s) { g_PreviousShader = s; }
+
+void GR_SetBlendMode(BlendMode bm)
+{
+	g_PreviousBlendMode = bm;
+	g_vkActiveBlendMode = (int)bm;
+}
+void GR_SetPolygonOffset(float) {}
+void GR_SetStencilMode(int v)    { g_PreviousStencilMode = v; }
+void GR_EnableDepth(int v)       { g_PreviousDepthMode = v; }
+// Engine state owned by PsyX_GPU.cpp — needed by GR_SetupClipMode to
+// translate the engine's PSX-space clip rect into a window-space scissor.
+extern "C" { extern DISPENV activeDispEnv; }
+
+void GR_SetScissorState(int v)
+{
+	g_PreviousScissorState = v;
+	if (!g_vkSceneRecording) return;
+	if (!v) {
+		// Disable → full-window scissor (Vulkan can't actually disable
+		// scissor like GL can, so we just set it to cover everything).
+		VkRect2D sc = { {0, 0}, g_vkSwapchainExtent };
+		vkCmdSetScissor(g_vkCmdBuffers[g_vkCurrentFrame], 0, 1, &sc);
+	}
+}
+// Mirror of the GL backend: this is the routine the engine calls before
+// every draw split, and where the projection matrices for that split are
+// set. Without this the push-constant matrices stay at identity and PSX
+// pixel-space vertices land far outside the clip volume → black screen.
+void GR_SetOffscreenState(const RECT16* offscreenRect, int enable)
+{
+	if (enable) {
+#if USE_PGXP
+		GR_Ortho2D(-0.5f, 0.5f, 0.5f, -0.5f, -1.0f, 1.0f);
+#else
+		GR_Ortho2D(0, offscreenRect->w, offscreenRect->h, 0, -1.0f, 1.0f);
+#endif
+	} else {
+#if USE_PGXP
+		const float perspectiveFOV   = 0.9265f;
+		const float perspectiveZNear = 0.25f;
+		const float perspectiveZFar  = 1000.0f;
+		const float PSX_ASPECT       = (240.0f / 320.0f);
+		const float emuScreenAspect  = (float)g_windowWidth / (float)g_windowHeight;
+		GR_Ortho2D(-0.5f * emuScreenAspect * PSX_ASPECT,
+		            0.5f * emuScreenAspect * PSX_ASPECT,
+		            0.5f, -0.5f, -1.0f, 1.0f);
+		GR_Perspective3D(perspectiveFOV, 1.0f, 1.0f / (emuScreenAspect * PSX_ASPECT),
+		                 perspectiveZNear, perspectiveZFar);
+#else
+		// Fallback for non-PGXP builds — uses framebuffer (320x240 typical)
+		GR_Ortho2D(0, 320, 240, 0, -1.0f, 1.0f);
+#endif
+	}
+	g_PreviousOffscreenState = enable;
+}
+// Port of the GL backend's GR_SetupClipMode. Translates an engine
+// PSX-space RECT16 into a VkRect2D scissor that lines up with the
+// widescreen-mapped viewport. Without this the mini-map quad's
+// texture leaks outside its frame, and many world primitives that
+// the engine *intends* to clip render outside their proper region.
+void GR_SetupClipMode(const RECT16* rect, int enable)
+{
+	if (!g_vkSceneRecording) return;
+	VkCommandBuffer cb = g_vkCmdBuffers[g_vkCurrentFrame];
+
+	const bool scissorOn = enable && (
+		activeDispEnv.isinter ||
+		(rect->x - activeDispEnv.disp.x > 0 ||
+		 rect->y - activeDispEnv.disp.y > 0 ||
+		 rect->w < activeDispEnv.disp.w - 1 ||
+		 rect->h < activeDispEnv.disp.h - 1));
+
+	if (!scissorOn) {
+		VkRect2D sc = { {0, 0}, g_vkSwapchainExtent };
+		vkCmdSetScissor(cb, 0, 1, &sc);
+		return;
+	}
+
+	const float PSX_ASPECT = 240.0f / 320.0f;
+	const float emuScreenAspect = 1.0f / (PSX_ASPECT *
+		(float)g_windowWidth / (float)g_windowHeight);
+	const float psxScreenWInv = 1.0f / (float)activeDispEnv.disp.w;
+	const float psxScreenHInv = 1.0f / (float)activeDispEnv.disp.h;
+
+	float clipRectX = (float)(rect->x - activeDispEnv.disp.x) * psxScreenWInv;
+	float clipRectY = (float)(rect->y - activeDispEnv.disp.y) * psxScreenHInv;
+	float clipRectW = (float)(rect->w) * psxScreenWInv;
+	float clipRectH = (float)(rect->h) * psxScreenHInv;
+
+	clipRectX -= 0.5f;
+	clipRectX *= emuScreenAspect;
+	clipRectW *= emuScreenAspect;
+	clipRectX += 0.5f;
+
+	int crx = (int)(clipRectX * (float)g_windowWidth);
+	int cry = (int)(clipRectY * (float)g_windowHeight);
+	int crw = (int)(clipRectW * (float)g_windowWidth);
+	int crh = (int)(clipRectH * (float)g_windowHeight);
+
+	// Clamp to swapchain extent — Vulkan rejects scissors that extend
+	// beyond the framebuffer with VK_ERROR_VALIDATION_FAILED.
+	if (crx < 0) { crw += crx; crx = 0; }
+	if (cry < 0) { crh += cry; cry = 0; }
+	const int maxW = (int)g_vkSwapchainExtent.width;
+	const int maxH = (int)g_vkSwapchainExtent.height;
+	if (crx + crw > maxW) crw = maxW - crx;
+	if (cry + crh > maxH) crh = maxH - cry;
+	if (crw < 0) crw = 0;
+	if (crh < 0) crh = 0;
+
+	VkRect2D sc = { {crx, cry}, {(uint32_t)crw, (uint32_t)crh} };
+	vkCmdSetScissor(cb, 0, 1, &sc);
+}
+void GR_SetViewPort(int x, int y, int width, int height)
+{
+	if (!g_vkSceneRecording) return;
+	VkCommandBuffer cb = g_vkCmdBuffers[g_vkCurrentFrame];
+	// Same Y-flip trick as the BeginScene default viewport.
+	VkViewport vp = {};
+	vp.x = (float)x;
+	vp.y = (float)(y + height);
+	vp.width  =  (float)width;
+	vp.height = -(float)height;
+	vp.minDepth = 0.0f; vp.maxDepth = 1.0f;
+	vkCmdSetViewport(cb, 0, 1, &vp);
+}
+void GR_SetTexture(TextureID t, TexFormat) { g_lastBoundTexture = t; }
+void GR_SetOverrideTextureSize(int, int) {}
+void GR_SetWireframe(int v)      { g_dbg_wireframeMode = v; }
+
+void GR_DestroyTexture(TextureID) {}
+
+void GR_PushDebugLabel(const char*) {}
+void GR_PopDebugLabel() {}
+
+void PsyX_GetPSXWidescreenMappedViewport(struct _RECT16* /*rect*/) {}
+
+#endif // RENDERER_VK

--- a/src/render/PsyX_render_vk.cpp
+++ b/src/render/PsyX_render_vk.cpp
@@ -39,6 +39,9 @@
 #include <vector>
 #include <algorithm>
 #include <unordered_map>
+#include <float.h>
+#include <math.h>
+#include <stdint.h>
 
 // =======================================================================
 // Engine-side globals (parity with GL backend)
@@ -96,6 +99,7 @@ VkPhysicalDeviceMemoryProperties g_vkMemProps = {};
 VkSwapchainKHR     g_vkSwapchain       = VK_NULL_HANDLE;
 VkFormat           g_vkSwapchainFormat = VK_FORMAT_UNDEFINED;
 VkExtent2D         g_vkSwapchainExtent = {0, 0};
+bool               g_vkSwapchainCanReadback = false;
 std::vector<VkImage>     g_vkSwapchainImages;
 std::vector<VkImageView> g_vkSwapchainImageViews;
 std::vector<VkFramebuffer> g_vkFramebuffers;
@@ -130,13 +134,24 @@ float              g_vkClearColor[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
 // GR_Shader_Compile call.
 shaderc_compiler_t   g_shadercCompiler = nullptr;
 
-// One graphics pipeline per PSX blend mode. GR_SetBlendMode picks the
-// active one; GR_DrawTriangles re-binds if it differs from what's
-// currently bound on the command buffer.
+enum
+{
+	kVkDepthDisabled = 0,
+	kVkDepthEnabled = 1,
+	kVkDepthModeCount = 2,
+	kVkBlendModeCount = 5
+};
+
 VkPipelineLayout     g_vkPipelineLayout = VK_NULL_HANDLE;
-VkPipeline           g_vkPipelines[5]   = {}; // indexed by BlendMode enum
-int                  g_vkBoundPipelineIdx = -1;
+VkPipeline           g_vkPipelines[kVkDepthModeCount][kVkBlendModeCount] = {};
+int                  g_vkBoundPipelineKey = -1;
 int                  g_vkActiveBlendMode  = BM_NONE;
+int                  g_vkActiveDepthMode  = kVkDepthEnabled;
+
+static int GetPipelineKey(int depthMode, int blendMode)
+{
+	return depthMode * kVkBlendModeCount + blendMode;
+}
 
 // Default vertex/fragment shader modules used by the solid pipeline.
 VkShaderModule       g_vkVertModule = VK_NULL_HANDLE;
@@ -150,10 +165,10 @@ VkDeviceMemory       g_vkVramImageMem   = VK_NULL_HANDLE;
 VkImageView          g_vkVramImageView  = VK_NULL_HANDLE;
 VkSampler            g_vkVramSampler    = VK_NULL_HANDLE;
 
-// Staging buffer used to upload the CPU-side `vram[]` to the GPU image.
-VkBuffer             g_vkVramStaging      = VK_NULL_HANDLE;
-VkDeviceMemory       g_vkVramStagingMem   = VK_NULL_HANDLE;
-void*                g_vkVramStagingMap   = nullptr;
+// Staging buffers used to upload the CPU-side `vram[]` to the GPU image.
+VkBuffer             g_vkVramStaging[kMaxFramesInFlight]    = {};
+VkDeviceMemory       g_vkVramStagingMem[kMaxFramesInFlight] = {};
+void*                g_vkVramStagingMap[kMaxFramesInFlight] = {};
 
 // Descriptor set layout / pool / set bound to the pipeline at slot 0.
 VkDescriptorSetLayout g_vkDescSetLayout = VK_NULL_HANDLE;
@@ -162,11 +177,11 @@ VkDescriptorSet       g_vkDescSet       = VK_NULL_HANDLE;
 
 bool                 g_vkVramDirty      = true;
 
-// Vertex buffer (host-visible, persistently mapped). Sized to PsyX's
+// Vertex buffers (host-visible, persistently mapped). Sized to PsyX's
 // MAX_VERTEX_BUFFER_SIZE upper bound.
-VkBuffer             g_vkVertexBuffer = VK_NULL_HANDLE;
-VkDeviceMemory       g_vkVertexBufferMem = VK_NULL_HANDLE;
-void*                g_vkVertexBufferMap = nullptr;
+VkBuffer             g_vkVertexBuffer[kMaxFramesInFlight]    = {};
+VkDeviceMemory       g_vkVertexBufferMem[kMaxFramesInFlight] = {};
+void*                g_vkVertexBufferMap[kMaxFramesInFlight] = {};
 uint32_t             g_vkVertexBufferSize = 0; // in vertices currently uploaded
 
 // Push constants — both projection matrices in one block. Vulkan
@@ -202,6 +217,270 @@ unsigned short g_vkVramCPU[VRAM_WIDTH * VRAM_HEIGHT] = {};
 			eprinterr("Vulkan call failed: %s -> %d\n", #expr, _r);   \
 		}                                                             \
 	} while (0)
+
+bool VkDiagEnabled()
+{
+	static int cached = -1;
+	if (cached < 0) {
+		const char* value = getenv("REDRIVER2_VK_DIAG");
+		cached = (value && atoi(value) != 0) ? 1 : 0;
+	}
+	return cached != 0;
+}
+
+int VkDiagInterval()
+{
+	static int cached = -1;
+	if (cached < 0) {
+		const char* value = getenv("REDRIVER2_VK_DIAG_INTERVAL");
+		cached = value ? atoi(value) : 60;
+		if (cached < 1)
+			cached = 1;
+	}
+	return cached;
+}
+
+bool VkDrawLogEnabled()
+{
+	static int cached = -1;
+	if (cached < 0) {
+		const char* value = getenv("REDRIVER2_VK_DRAW_LOG");
+		cached = (value && atoi(value) != 0) ? 1 : 0;
+	}
+	return cached != 0;
+}
+
+int VkCaptureFrame()
+{
+	static int cached = -2;
+	if (cached == -2) {
+		const char* value = getenv("REDRIVER2_VK_CAPTURE_FRAME");
+		cached = value ? atoi(value) : -1;
+	}
+	return cached;
+}
+
+const char* VkCapturePath()
+{
+	const char* path = getenv("REDRIVER2_VK_CAPTURE_PATH");
+	return path ? path : "REDRIVER2_VK_CAPTURE.bmp";
+}
+
+struct VkDiagFrameStats {
+	uint64_t draws;
+	uint64_t triangles;
+	uint64_t depthEnabledDraws;
+	uint64_t depthDisabledDraws;
+	uint64_t depthEnabledTriangles;
+	uint64_t depthDisabledTriangles;
+	uint64_t pgxpTriangles;
+	uint64_t flatTriangles;
+	uint64_t mixedTriangles;
+	uint64_t pgxpWithoutDepth;
+	uint64_t flatWithDepth;
+	uint64_t rejectLeft;
+	uint64_t rejectRight;
+	uint64_t rejectTop;
+	uint64_t rejectBottom;
+	uint64_t rejectNear;
+	uint64_t rejectFar;
+	uint64_t anyNonPositiveW;
+	uint64_t allNonPositiveW;
+	float minW;
+	float maxW;
+	float minZ;
+	float maxZ;
+	float minNdcZ;
+	float maxNdcZ;
+};
+
+VkDiagFrameStats g_vkDiagStats = {};
+uint64_t g_vkDiagFrame = 0;
+
+void VkDiagResetFrame()
+{
+	memset(&g_vkDiagStats, 0, sizeof(g_vkDiagStats));
+	g_vkDiagStats.minW = FLT_MAX;
+	g_vkDiagStats.maxW = -FLT_MAX;
+	g_vkDiagStats.minZ = FLT_MAX;
+	g_vkDiagStats.maxZ = -FLT_MAX;
+	g_vkDiagStats.minNdcZ = FLT_MAX;
+	g_vkDiagStats.maxNdcZ = -FLT_MAX;
+}
+
+void VkDiagMulMat4Vec4(const float* m, const float* in, float* out)
+{
+	out[0] = m[0] * in[0] + m[4] * in[1] + m[8]  * in[2] + m[12] * in[3];
+	out[1] = m[1] * in[0] + m[5] * in[1] + m[9]  * in[2] + m[13] * in[3];
+	out[2] = m[2] * in[0] + m[6] * in[1] + m[10] * in[2] + m[14] * in[3];
+	out[3] = m[3] * in[0] + m[7] * in[1] + m[11] * in[2] + m[15] * in[3];
+}
+
+bool VkDiagVertexIsPGXP(const GrVertex& v)
+{
+#if USE_PGXP
+	return v.scr_h > 100.0f;
+#else
+	(void)v;
+	return false;
+#endif
+}
+
+void VkDiagVertexToClip(const GrVertex& v, float* out)
+{
+#if USE_PGXP
+	const bool fmvLike = (v.z == 0.0f && v.scr_h == 0.0f && v.a == 0);
+	if (fmvLike) {
+		out[0] = v.x;
+		out[1] = v.y;
+		out[2] = 0.5f;
+		out[3] = 1.0f;
+	} else if (v.scr_h > 100.0f) {
+		const float in[4] = {
+			(v.x + 0.5f) * v.scr_h,
+			(v.y + 0.5f) * -v.scr_h,
+			v.z,
+			1.0f
+		};
+		VkDiagMulMat4Vec4(g_vkPushBlock.Projection3D, in, out);
+		out[0] += v.ofsX * out[3];
+		out[1] += -v.ofsY * out[3];
+	} else {
+		const float in[4] = { v.x, v.y, 0.5f, 1.0f };
+		VkDiagMulMat4Vec4(g_vkPushBlock.Projection, in, out);
+	}
+#else
+	const float in[4] = { (float)v.x, (float)v.y, 0.5f, 1.0f };
+	VkDiagMulMat4Vec4(g_vkPushBlock.Projection, in, out);
+#endif
+	out[2] = (out[2] + out[3]) * 0.5f;
+}
+
+void VkDiagAccumulateDraw(int startVertex, int triangles)
+{
+	if (!VkDiagEnabled() || triangles <= 0)
+		return;
+
+	const GrVertex* vertices = (const GrVertex*)g_vkVertexBufferMap[g_vkCurrentFrame];
+	if (!vertices)
+		return;
+
+	const int maxTriangles = std::max(0, ((int)g_vkVertexBufferSize - startVertex) / 3);
+	triangles = std::min(triangles, maxTriangles);
+	if (triangles <= 0)
+		return;
+
+	g_vkDiagStats.draws++;
+	g_vkDiagStats.triangles += (uint64_t)triangles;
+
+	const int depthIdx = (g_vkActiveDepthMode == kVkDepthEnabled && g_cfg_pgxpZBuffer)
+		? kVkDepthEnabled : kVkDepthDisabled;
+
+	if (depthIdx == kVkDepthEnabled) {
+		g_vkDiagStats.depthEnabledDraws++;
+		g_vkDiagStats.depthEnabledTriangles += (uint64_t)triangles;
+	} else {
+		g_vkDiagStats.depthDisabledDraws++;
+		g_vkDiagStats.depthDisabledTriangles += (uint64_t)triangles;
+	}
+
+	for (int i = 0; i < triangles; ++i) {
+		const GrVertex* tri = vertices + startVertex + i * 3;
+		float clip[3][4];
+		int pgxpVerts = 0;
+		int nonPositiveW = 0;
+
+		for (int v = 0; v < 3; ++v) {
+			if (VkDiagVertexIsPGXP(tri[v]))
+				pgxpVerts++;
+
+			VkDiagVertexToClip(tri[v], clip[v]);
+
+			if (clip[v][3] <= 0.0f)
+				nonPositiveW++;
+
+			g_vkDiagStats.minW = std::min(g_vkDiagStats.minW, clip[v][3]);
+			g_vkDiagStats.maxW = std::max(g_vkDiagStats.maxW, clip[v][3]);
+			g_vkDiagStats.minZ = std::min(g_vkDiagStats.minZ, clip[v][2]);
+			g_vkDiagStats.maxZ = std::max(g_vkDiagStats.maxZ, clip[v][2]);
+
+			if (fabsf(clip[v][3]) > 0.000001f) {
+				const float ndcZ = clip[v][2] / clip[v][3];
+				g_vkDiagStats.minNdcZ = std::min(g_vkDiagStats.minNdcZ, ndcZ);
+				g_vkDiagStats.maxNdcZ = std::max(g_vkDiagStats.maxNdcZ, ndcZ);
+			}
+		}
+
+		if (pgxpVerts == 3) {
+			g_vkDiagStats.pgxpTriangles++;
+			if (depthIdx != kVkDepthEnabled)
+				g_vkDiagStats.pgxpWithoutDepth++;
+		} else if (pgxpVerts == 0) {
+			g_vkDiagStats.flatTriangles++;
+			if (depthIdx == kVkDepthEnabled)
+				g_vkDiagStats.flatWithDepth++;
+		} else {
+			g_vkDiagStats.mixedTriangles++;
+		}
+
+		if (nonPositiveW > 0)
+			g_vkDiagStats.anyNonPositiveW++;
+		if (nonPositiveW == 3)
+			g_vkDiagStats.allNonPositiveW++;
+
+		if (clip[0][0] < -clip[0][3] && clip[1][0] < -clip[1][3] && clip[2][0] < -clip[2][3])
+			g_vkDiagStats.rejectLeft++;
+		if (clip[0][0] > clip[0][3] && clip[1][0] > clip[1][3] && clip[2][0] > clip[2][3])
+			g_vkDiagStats.rejectRight++;
+		if (clip[0][1] < -clip[0][3] && clip[1][1] < -clip[1][3] && clip[2][1] < -clip[2][3])
+			g_vkDiagStats.rejectTop++;
+		if (clip[0][1] > clip[0][3] && clip[1][1] > clip[1][3] && clip[2][1] > clip[2][3])
+			g_vkDiagStats.rejectBottom++;
+		if (clip[0][2] < 0.0f && clip[1][2] < 0.0f && clip[2][2] < 0.0f)
+			g_vkDiagStats.rejectNear++;
+		if (clip[0][2] > clip[0][3] && clip[1][2] > clip[1][3] && clip[2][2] > clip[2][3])
+			g_vkDiagStats.rejectFar++;
+	}
+}
+
+void VkDiagLogFrame()
+{
+	if (!VkDiagEnabled() || g_vkDiagStats.triangles == 0)
+		return;
+
+	if ((g_vkDiagFrame % (uint64_t)VkDiagInterval()) != 0)
+		return;
+
+	eprintinfo("[VKDIAG][frame=%llu] draws=%llu tris=%llu depth on/off draws=%llu/%llu tris=%llu/%llu pgxp=%llu flat=%llu mixed=%llu bad pgxpNoDepth/flatDepth=%llu/%llu "
+		"clipReject L/R/T/B/N/F=%llu/%llu/%llu/%llu/%llu/%llu w<=0 any/all=%llu/%llu "
+		"clipW=[%.3f %.3f] clipZ=[%.3f %.3f] ndcZ=[%.3f %.3f]\n",
+		(unsigned long long)g_vkDiagFrame,
+		(unsigned long long)g_vkDiagStats.draws,
+		(unsigned long long)g_vkDiagStats.triangles,
+		(unsigned long long)g_vkDiagStats.depthEnabledDraws,
+		(unsigned long long)g_vkDiagStats.depthDisabledDraws,
+		(unsigned long long)g_vkDiagStats.depthEnabledTriangles,
+		(unsigned long long)g_vkDiagStats.depthDisabledTriangles,
+		(unsigned long long)g_vkDiagStats.pgxpTriangles,
+		(unsigned long long)g_vkDiagStats.flatTriangles,
+		(unsigned long long)g_vkDiagStats.mixedTriangles,
+		(unsigned long long)g_vkDiagStats.pgxpWithoutDepth,
+		(unsigned long long)g_vkDiagStats.flatWithDepth,
+		(unsigned long long)g_vkDiagStats.rejectLeft,
+		(unsigned long long)g_vkDiagStats.rejectRight,
+		(unsigned long long)g_vkDiagStats.rejectTop,
+		(unsigned long long)g_vkDiagStats.rejectBottom,
+		(unsigned long long)g_vkDiagStats.rejectNear,
+		(unsigned long long)g_vkDiagStats.rejectFar,
+		(unsigned long long)g_vkDiagStats.anyNonPositiveW,
+		(unsigned long long)g_vkDiagStats.allNonPositiveW,
+		(double)g_vkDiagStats.minW,
+		(double)g_vkDiagStats.maxW,
+		(double)g_vkDiagStats.minZ,
+		(double)g_vkDiagStats.maxZ,
+		(double)g_vkDiagStats.minNdcZ,
+		(double)g_vkDiagStats.maxNdcZ);
+}
 
 uint32_t FindMemoryTypeIndex(uint32_t typeBits, VkMemoryPropertyFlags wanted)
 {
@@ -266,6 +545,74 @@ bool CreateBuffer(VkDeviceSize size, VkBufferUsageFlags usage,
 
 	VK_CHECK(vkBindBufferMemory(g_vkDevice, *outBuffer, *outMem, 0));
 	return true;
+}
+
+void SwapchainImageBarrier(VkCommandBuffer cb,
+                           VkImageLayout oldLayout, VkImageLayout newLayout,
+                           VkAccessFlags srcAccess, VkAccessFlags dstAccess,
+                           VkPipelineStageFlags srcStage, VkPipelineStageFlags dstStage)
+{
+	VkImageMemoryBarrier b = {};
+	b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+	b.oldLayout = oldLayout;
+	b.newLayout = newLayout;
+	b.srcAccessMask = srcAccess;
+	b.dstAccessMask = dstAccess;
+	b.image = g_vkSwapchainImages[g_vkAcquiredImageIdx];
+	b.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	b.subresourceRange.levelCount = 1;
+	b.subresourceRange.layerCount = 1;
+	vkCmdPipelineBarrier(cb, srcStage, dstStage, 0, 0, nullptr, 0, nullptr, 1, &b);
+}
+
+bool WriteBgraBmp(const char* path, const unsigned char* pixels, uint32_t width, uint32_t height)
+{
+	FILE* fp = fopen(path, "wb");
+	if (!fp)
+		return false;
+
+	const uint32_t pixelBytes = width * height * 4;
+	const uint32_t fileBytes = 14 + 40 + pixelBytes;
+	const int32_t topDownHeight = -(int32_t)height;
+	unsigned char fileHeader[14] = {
+		'B', 'M',
+		(unsigned char)(fileBytes), (unsigned char)(fileBytes >> 8), (unsigned char)(fileBytes >> 16), (unsigned char)(fileBytes >> 24),
+		0, 0, 0, 0,
+		54, 0, 0, 0
+	};
+	unsigned char infoHeader[40] = {};
+	infoHeader[0] = 40;
+	infoHeader[4] = (unsigned char)(width);
+	infoHeader[5] = (unsigned char)(width >> 8);
+	infoHeader[6] = (unsigned char)(width >> 16);
+	infoHeader[7] = (unsigned char)(width >> 24);
+	infoHeader[8] = (unsigned char)(topDownHeight);
+	infoHeader[9] = (unsigned char)(topDownHeight >> 8);
+	infoHeader[10] = (unsigned char)(topDownHeight >> 16);
+	infoHeader[11] = (unsigned char)(topDownHeight >> 24);
+	infoHeader[12] = 1;
+	infoHeader[14] = 32;
+
+	fwrite(fileHeader, 1, sizeof(fileHeader), fp);
+	fwrite(infoHeader, 1, sizeof(infoHeader), fp);
+	fwrite(pixels, 1, pixelBytes, fp);
+	fclose(fp);
+	return true;
+}
+
+void ConvertSwapchainPixelsToBgra(unsigned char* pixels, uint32_t width, uint32_t height)
+{
+	if (g_vkSwapchainFormat == VK_FORMAT_B8G8R8A8_UNORM ||
+		g_vkSwapchainFormat == VK_FORMAT_B8G8R8A8_SRGB)
+		return;
+
+	if (g_vkSwapchainFormat == VK_FORMAT_R8G8B8A8_UNORM ||
+		g_vkSwapchainFormat == VK_FORMAT_R8G8B8A8_SRGB) {
+		for (uint32_t i = 0; i < width * height; ++i) {
+			unsigned char* p = pixels + i * 4;
+			std::swap(p[0], p[2]);
+		}
+	}
 }
 
 VkShaderModule CreateShaderModule(const uint32_t* spirv, size_t bytes)
@@ -362,139 +709,116 @@ void main() {
     if (fmvLike) {
         gl_Position = vec4(a_position.xy, 0.5, 1.0);
     } else if (a_zw.y > 100.0) {
-        gl_Position = pb.Projection3D * vec4(a_position.xy * a_zw.y, a_zw.x, 1.0);
+        const vec2 geom_ofs = vec2(0.5, 0.5);
+        vec4 p = pb.Projection3D * vec4((a_position.xy + geom_ofs) *
+                                          vec2(1.0, -1.0) * a_zw.y,
+                                         a_zw.x, 1.0);
+        p.x += a_zw.z * p.w;
+        p.y += -a_zw.w * p.w;
+        gl_Position = p;
     } else {
         gl_Position = pb.Projection * vec4(a_position.xy, 0.5, 1.0);
     }
 
-    // GL→Vulkan NDC z remap. The projection matrices were copied verbatim
-    // from the OpenGL backend, which emits clip-space z in [-w, w] (NDC
-    // z ∈ [-1, 1]). Vulkan's clip volume is z ∈ [0, w] (NDC z ∈ [0, 1]),
-    // so without this remap every primitive lands outside the clip volume
-    // and gets discarded — leaving the screen black.
     gl_Position.z = (gl_Position.z + gl_Position.w) * 0.5;
+
     v_color = a_color;
     v_texcoord = a_texcoord;
 
-    // PSX texture page → VRAM coords:
-    //   page is bits-packed: low 4 bits = X / 64, next 1 bit = Y / 256
-    //   the actual texture page format (4/8/16-bit) is in bits 7-8 of the
-    //   tpage word, but we receive `page` already split.
-    // For a first cut we extract:
-    //   page_x = (page & 0x0F) * 64
-    //   page_y = ((page >> 4) & 0x01) * 256
-    //   tex_format = (page >> 7) & 0x03   (0=4bit, 1=8bit, 2/3=16bit)
-    //   clut_x = (clut & 0x3F) * 16
-    //   clut_y = (clut >> 6)
-    // Pass them along so the fragment shader can sample.
+    // page → pixel coords, clut → NORMALISED [0, 1] coords.
     float pageRaw = a_position.z;
     float clutRaw = a_position.w;
-    float pageX = mod(pageRaw, 16.0) * 64.0;
-    float pageY = floor(pageRaw / 16.0);
-    pageY = mod(pageY, 2.0) * 256.0;
-    float texFormat = floor(pageRaw / 128.0);
-    texFormat = mod(texFormat, 4.0);
-    float clutX = mod(clutRaw, 64.0) * 16.0;
-    float clutY = floor(clutRaw / 64.0);
-    v_page_clut = vec4(pageX, pageY, clutX, clutY);
-    // Stash format in the otherwise-unused dither slot so the fragment
-    // shader picks the right decode path.
-    v_texcoord.w = texFormat;
+    v_page_clut.x = fract(pageRaw / 16.0) * 1024.0;
+    v_page_clut.y = floor(pageRaw / 16.0) * 256.0;
+    v_page_clut.z = fract(clutRaw / 64.0);
+    v_page_clut.w = floor(clutRaw / 64.0) / 512.0;
+    // [A] Sub-texel bias (matches GL backend's c_UVFudge): nudge clut UV
+    // away from a texel boundary so NEAREST sampling can't drift one
+    // texel left and pull index-0 (transparency mask) for 4-bit STP=1
+    // sprites like the car wheels. zw is normalised, x/y are pixel-space
+    // and already have the integer-pixel center implied by R8G8 sampling.
+    v_page_clut.zw += vec2(0.00025, 0.00025);
+    v_texcoord.w = mod(floor(pageRaw / 128.0), 4.0);
 }
 )GLSL";
 
 const char* kBasicFragSrc = R"GLSL(
 #version 450
+// 1:1 port of the GL backend's GPU_FRAGMENT_SAMPLE_SHADER (4/8/16-bit
+// variants merged into one branched routine, since we don't have multi-
+// pipeline shader switching yet). VRAM is exposed as R8G8_UNORM:
+// low byte → .r, high byte → .g (matches GL's GL_RG / GL_UNSIGNED_BYTE
+// upload of the engine's `unsigned short vram[]`).
+// v_texcoord.w doubles as the texture format (0=4-bit, 1=8-bit, 2=16-bit)
+// — the vertex shader writes it there. Frees us from a separate varying
+// slot at the cost of overwriting the dither index, which we don't sample
+// in this revision anyway.
 layout(location = 0) in vec4 v_color;
-layout(location = 1) in vec4 v_texcoord;     // u, v, bright, texFormat
-layout(location = 2) in vec4 v_page_clut;    // pageX, pageY, clutX, clutY
+layout(location = 1) in vec4 v_texcoord;
+layout(location = 2) in vec4 v_page_clut;
 
 layout(location = 0) out vec4 out_color;
 
-// VRAM as R8G8 unorm (low byte = R, high byte = G).
 layout(set = 0, binding = 0) uniform sampler2D s_vram;
 
-const float VRAM_W = 1024.0;
-const float VRAM_H = 512.0;
+const vec2  c_VRAMTexel = vec2(1.0 / 1024.0, 1.0 / 512.0);
+const float c_PackRange = 255.001;
 
-// Decode a 16-bit packed (low,high) byte pair to the raw u16 value.
-float pack_rg_u16(vec2 rg) {
-    return floor(rg.x * 255.0 + 0.5) + floor(rg.y * 255.0 + 0.5) * 256.0;
+// Inline the GL helpers verbatim — same pack / decode arithmetic.
+float packRG(vec2 rg) {
+    return (rg.y * 256.0 + rg.x) * c_PackRange;
 }
-
-// PSX 16-bit pixel — bits 0-4 = R, 5-9 = G, 10-14 = B, bit 15 = STP
-// (semitransparency / mask). When STP=0 the pixel is opaque (alpha=1),
-// when STP=1 it should blend with the active ABR mode (alpha=0.5 so
-// VK_BLEND_FACTOR_SRC_ALPHA in the BM_AVERAGE pipeline produces the
-// 50/50 mix the PSX expects; the BM_ADD/SUBTRACT pipelines ignore the
-// alpha because their factors are ONE/ONE).
-vec4 psx16_to_rgba(float v16) {
-    float r = mod(v16, 32.0);                v16 = floor(v16 / 32.0);
-    float g = mod(v16, 32.0);                v16 = floor(v16 / 32.0);
-    float b = mod(v16, 32.0);                v16 = floor(v16 / 32.0);
-    float stp = mod(v16, 2.0);  // 0 or 1
-    return vec4(r / 31.0, g / 31.0, b / 31.0, stp > 0.5 ? 0.5 : 1.0);
+vec4 decodeRG(float rg) {
+    vec4 value = fract(floor(rg / vec4(1.0, 32.0, 1024.0, 32768.0)) / 32.0);
+    return vec4(value.xyz, rg == 0.0 ? rg : (1.0 - value.w * 16.0));
 }
+vec2 VRAM(vec2 uv) { return texture(s_vram, uv).rg; }
 
-// Read the raw 16-bit value at integer VRAM (x,y).
-float read_vram_u16(float x, float y) {
-    vec2 uv = vec2((x + 0.5) / VRAM_W, (y + 0.5) / VRAM_H);
-    return pack_rg_u16(texture(s_vram, uv).rg);
+float samplePSX(vec2 tc) {
+    float fmt = v_texcoord.w;
+    if (fmt < 0.5) {
+        // 4-bit paletted: 4 pixels per VRAM cell
+        vec2 uv = (tc * vec2(0.25, 1.0) + v_page_clut.xy) * c_VRAMTexel;
+        vec2 comp = VRAM(uv);
+        int  index = int(fract(tc.x / 4.0 + 0.0001) * 4.0);
+        // pull the right nibble from the (low, high) bytes
+        float v = (index < 2 ? comp.x : comp.y) * (c_PackRange / 16.0);
+        float f = floor(v);
+        vec2 c = vec2((v - f) * 16.0, f);
+        vec2 clut_pos = v_page_clut.zw;
+        clut_pos.x += mix(c[0], c[1], mod(float(index), 2.0)) * c_VRAMTexel.x;
+        return packRG(VRAM(clut_pos));
+    } else if (fmt < 1.5) {
+        // 8-bit paletted: 2 pixels per VRAM cell
+        vec2 uv = (tc * vec2(0.5, 1.0) + v_page_clut.xy) * c_VRAMTexel;
+        vec2 comp = VRAM(uv);
+        vec2 clut_pos = v_page_clut.zw;
+        int index = int(mod(tc.x, 2.0));
+        clut_pos.x += (index == 0 ? comp.x : comp.y) * c_PackRange * c_VRAMTexel.x;
+        return packRG(VRAM(clut_pos));
+    } else {
+        // 16-bit direct
+        vec2 uv = (tc + v_page_clut.xy) * c_VRAMTexel;
+        return packRG(VRAM(uv));
+    }
 }
 
 void main() {
-    // bright (a_texcoord.z, raw u8 0..255) is the engine's untextured
-    // marker: PsyX_GPU::MakeTexcoordTriangleZero/QuadZero set bright=1
-    // for untextured fills, MakeTexcoordTriangle/Quad sets bright=2 for
-    // textured ones. So bright<=1.5 → no texture sampling, just vertex
-    // colour. Avoids the "page=0+uv=0 happens to be a real texel"
-    // ambiguity that previously made the player character grey.
+    // Untextured fill (engine sets bright=1 for these via
+    // MakeTexcoordTriangleZero/QuadZero); flat-shaded vertex colour
+    // doubled so PSX-neutral rgba=128 (=0.5 normalised) lands at 1.0.
     if (v_texcoord.z < 1.5) {
         out_color = vec4(min(v_color.rgb * 2.0, vec3(1.0)), 1.0);
         return;
     }
 
-    // FLOOR the interpolated UV to integer texel coordinates BEFORE doing
-    // any palette-index math. Otherwise sub-texel fractions leak into
-    // mod(u,2)/mod(u,4)/pow(16,sub) and produce wrong palette indices,
-    // which manifests as the high-frequency noise pattern across the whole
-    // textured surface.
-    float u = floor(v_texcoord.x + 0.0001);   // 0..255 integer texel
-    float v = floor(v_texcoord.y + 0.0001);
-    float fmt = v_texcoord.w;      // 0=4bit, 1=8bit, 2/3=16bit
-    vec2 page = v_page_clut.xy;
-    vec2 clut = v_page_clut.zw;
+    float color_16 = samplePSX(v_texcoord.xy);
+    if (color_16 == 0.0) discard;
+    vec4 texel = decodeRG(color_16);
 
-    vec4 texel;
-    if (fmt < 0.5) {
-        // 4-bit paletted: 4 pixels per VRAM cell
-        float cellX = page.x + floor(u / 4.0);
-        float cellY = page.y + v;
-        float cell  = read_vram_u16(cellX, cellY);
-        float subX  = mod(u, 4.0);
-        float nibble = floor(cell / pow(16.0, subX));
-        nibble = mod(nibble, 16.0);
-        float c16 = read_vram_u16(clut.x + nibble, clut.y);
-        if (c16 == 0.0) discard;
-        texel = psx16_to_rgba(c16);
-    } else if (fmt < 1.5) {
-        // 8-bit paletted: 2 pixels per VRAM cell
-        float cellX = page.x + floor(u / 2.0);
-        float cellY = page.y + v;
-        float cell  = read_vram_u16(cellX, cellY);
-        float idx   = (mod(u, 2.0) < 0.5) ? mod(cell, 256.0) : floor(cell / 256.0);
-        float c16   = read_vram_u16(clut.x + idx, clut.y);
-        if (c16 == 0.0) discard;
-        texel = psx16_to_rgba(c16);
-    } else {
-        // 16-bit direct
-        float c16 = read_vram_u16(page.x + u, page.y + v);
-        if (c16 == 0.0) discard;
-        texel = psx16_to_rgba(c16);
-    }
-
-    // PSX modulates texel by 2× the vertex colour (rgba=128 → 1.0).
-    out_color = vec4(texel.rgb * min(v_color.rgb * 2.0, vec3(1.0)), texel.a);
+    // Same x2 modulation as the untextured path so neutral PSX vertex
+    // colour (rgba=128) doesn't dim the texture by 50 %.
+    out_color = vec4(texel.rgb * min(v_color.rgb * 2.0, vec3(1.0)), 1.0);
 }
 )GLSL";
 
@@ -641,6 +965,9 @@ bool CreateSwapchain(int width, int height)
 	ci.imageExtent = extent;
 	ci.imageArrayLayers = 1;
 	ci.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+	g_vkSwapchainCanReadback = (caps.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) != 0;
+	if (g_vkSwapchainCanReadback)
+		ci.imageUsage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
 	uint32_t qf[2] = { g_vkGraphicsQueueFamily, g_vkPresentQueueFamily };
 	if (g_vkGraphicsQueueFamily != g_vkPresentQueueFamily) {
@@ -832,23 +1159,33 @@ bool CreateVramImage()
 	si.magFilter = VK_FILTER_NEAREST;
 	si.minFilter = VK_FILTER_NEAREST;
 	si.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
-	si.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-	si.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-	si.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+	// [A] REPEAT, NOT CLAMP. The GL backend's tpage→UV math (`floor(pageRaw/16)*256`
+	// for page Y, `fract(pageRaw/16)*1024` for X) lets bits 5+ of tpage —
+	// which encode ABR / TP / dither — leak into the address. GL silently
+	// folds them back via the default GL_REPEAT wrap. With CLAMP_TO_EDGE
+	// every textured primitive whose tpage has TP=1 (8-bit) or ABR>0 ends
+	// up sampling row 511 of VRAM (the edge), so wheels/particles/anything
+	// that uses semitransparency reads garbage and renders as solid blocks.
+	si.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+	si.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+	si.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
 	si.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
 	si.unnormalizedCoordinates = VK_FALSE;
 	si.compareEnable = VK_FALSE;
 	VK_CHECK(vkCreateSampler(g_vkDevice, &si, nullptr, &g_vkVramSampler));
 
-	// Staging buffer (host-visible, persistently mapped) for VRAM uploads.
+	// One host-visible staging buffer per frame in flight. The CPU can start
+	// preparing frame N+1 before frame N's transfer has consumed its source.
 	const VkDeviceSize vramBytes = (VkDeviceSize)VRAM_WIDTH * VRAM_HEIGHT * sizeof(uint16_t);
-	if (!CreateBuffer(vramBytes,
-		VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-		VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-		&g_vkVramStaging, &g_vkVramStagingMem)) {
-		return false;
+	for (int i = 0; i < kMaxFramesInFlight; ++i) {
+		if (!CreateBuffer(vramBytes,
+			VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+			&g_vkVramStaging[i], &g_vkVramStagingMem[i])) {
+			return false;
+		}
+		VK_CHECK(vkMapMemory(g_vkDevice, g_vkVramStagingMem[i], 0, VK_WHOLE_SIZE, 0, &g_vkVramStagingMap[i]));
 	}
-	VK_CHECK(vkMapMemory(g_vkDevice, g_vkVramStagingMem, 0, VK_WHOLE_SIZE, 0, &g_vkVramStagingMap));
 	return true;
 }
 
@@ -934,7 +1271,7 @@ void TransitionVramToShaderRead(VkCommandBuffer cb)
 	r.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 	r.imageSubresource.layerCount = 1;
 	r.imageExtent = { VRAM_WIDTH, VRAM_HEIGHT, 1 };
-	vkCmdCopyBufferToImage(cb, g_vkVramStaging, g_vkVramImage,
+	vkCmdCopyBufferToImage(cb, g_vkVramStaging[g_vkCurrentFrame], g_vkVramImage,
 		VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &r);
 
 	VramImageBarrier(cb,
@@ -1032,8 +1369,12 @@ bool CreateBasicGraphicsPipeline()
 	dsOpaque.depthWriteEnable = VK_TRUE;
 	dsOpaque.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
 
-	VkPipelineDepthStencilStateCreateInfo dsBlend = dsOpaque;
-	dsBlend.depthWriteEnable = VK_FALSE;
+		VkPipelineDepthStencilStateCreateInfo dsBlend = dsOpaque;
+		dsBlend.depthWriteEnable = VK_FALSE;
+
+		VkPipelineDepthStencilStateCreateInfo dsDisabled = dsOpaque;
+		dsDisabled.depthTestEnable = VK_FALSE;
+		dsDisabled.depthWriteEnable = VK_FALSE;
 
 	// PSX blend modes — see GP0 ABR field. Mirror exactly what the GL
 	// backend does in GR_SetBlendMode (PsyX_render.cpp) so semi-trans
@@ -1087,13 +1428,13 @@ bool CreateBasicGraphicsPipeline()
 		return a;
 	};
 
-	VkPipelineColorBlendAttachmentState cbaArr[5];
-	VkPipelineColorBlendStateCreateInfo cbArr[5] = {};
-	for (int i = 0; i < 5; ++i) {
-		cbaArr[i] = blendForMode(i);
-		cbArr[i].sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
-		cbArr[i].attachmentCount = 1;
-		cbArr[i].pAttachments = &cbaArr[i];
+		VkPipelineColorBlendAttachmentState cbaArr[kVkBlendModeCount];
+		VkPipelineColorBlendStateCreateInfo cbArr[kVkBlendModeCount] = {};
+		for (int i = 0; i < kVkBlendModeCount; ++i) {
+			cbaArr[i] = blendForMode(i);
+			cbArr[i].sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+			cbArr[i].attachmentCount = 1;
+			cbArr[i].pAttachments = &cbaArr[i];
 	}
 
 	VkDynamicState dynStates[] = {
@@ -1130,15 +1471,17 @@ bool CreateBasicGraphicsPipeline()
 	gpci.renderPass = g_vkClearRenderPass;
 	gpci.subpass = 0;
 
-	// Build one PSO per blend mode — same vertex/fragment, the colour-
-	// blend state and depth-write change. GR_SetBlendMode picks the
-	// right index, GR_DrawTriangles re-binds when it changes.
+	// Build PSO variants for blend mode and depth state.
 	bool ok = true;
-	for (int i = 0; i < 5; ++i) {
-		gpci.pColorBlendState = &cbArr[i];
-		gpci.pDepthStencilState = (i == BM_NONE) ? &dsOpaque : &dsBlend;
-		VK_CHECK(vkCreateGraphicsPipelines(g_vkDevice, VK_NULL_HANDLE, 1, &gpci, nullptr, &g_vkPipelines[i]));
-		if (g_vkPipelines[i] == VK_NULL_HANDLE) ok = false;
+	for (int depthMode = 0; depthMode < kVkDepthModeCount; ++depthMode) {
+		for (int i = 0; i < kVkBlendModeCount; ++i) {
+			gpci.pColorBlendState = &cbArr[i];
+			gpci.pDepthStencilState = (depthMode == kVkDepthEnabled)
+				? ((i == BM_NONE) ? &dsOpaque : &dsBlend)
+				: &dsDisabled;
+			VK_CHECK(vkCreateGraphicsPipelines(g_vkDevice, VK_NULL_HANDLE, 1, &gpci, nullptr, &g_vkPipelines[depthMode][i]));
+			if (g_vkPipelines[depthMode][i] == VK_NULL_HANDLE) ok = false;
+		}
 	}
 	return ok;
 }
@@ -1146,13 +1489,15 @@ bool CreateBasicGraphicsPipeline()
 bool CreateVertexBuffer()
 {
 	const VkDeviceSize totalBytes = (VkDeviceSize)sizeof(GrVertex) * MAX_VERTEX_BUFFER_SIZE;
-	if (!CreateBuffer(totalBytes,
-		VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
-		VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-		&g_vkVertexBuffer, &g_vkVertexBufferMem)) {
-		return false;
+	for (int i = 0; i < kMaxFramesInFlight; ++i) {
+		if (!CreateBuffer(totalBytes,
+			VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+			&g_vkVertexBuffer[i], &g_vkVertexBufferMem[i])) {
+			return false;
+		}
+		VK_CHECK(vkMapMemory(g_vkDevice, g_vkVertexBufferMem[i], 0, VK_WHOLE_SIZE, 0, &g_vkVertexBufferMap[i]));
 	}
-	VK_CHECK(vkMapMemory(g_vkDevice, g_vkVertexBufferMem, 0, VK_WHOLE_SIZE, 0, &g_vkVertexBufferMap));
 	return true;
 }
 
@@ -1309,17 +1654,21 @@ void GR_Shutdown()
 		g_shadercCompiler = nullptr;
 	}
 
-	if (g_vkVertexBufferMap)  { vkUnmapMemory(g_vkDevice, g_vkVertexBufferMem); g_vkVertexBufferMap = nullptr; }
-	if (g_vkVertexBuffer)     { vkDestroyBuffer(g_vkDevice, g_vkVertexBuffer, nullptr);     g_vkVertexBuffer = VK_NULL_HANDLE; }
-	if (g_vkVertexBufferMem)  { vkFreeMemory(g_vkDevice, g_vkVertexBufferMem, nullptr);     g_vkVertexBufferMem = VK_NULL_HANDLE; }
+	for (int i = 0; i < kMaxFramesInFlight; ++i) {
+		if (g_vkVertexBufferMap[i]) { vkUnmapMemory(g_vkDevice, g_vkVertexBufferMem[i]); g_vkVertexBufferMap[i] = nullptr; }
+		if (g_vkVertexBuffer[i])    { vkDestroyBuffer(g_vkDevice, g_vkVertexBuffer[i], nullptr); g_vkVertexBuffer[i] = VK_NULL_HANDLE; }
+		if (g_vkVertexBufferMem[i]) { vkFreeMemory(g_vkDevice, g_vkVertexBufferMem[i], nullptr); g_vkVertexBufferMem[i] = VK_NULL_HANDLE; }
+	}
 
 	if (g_vkDepthImageView)   { vkDestroyImageView(g_vkDevice, g_vkDepthImageView, nullptr); g_vkDepthImageView = VK_NULL_HANDLE; }
 	if (g_vkDepthImage)       { vkDestroyImage(g_vkDevice, g_vkDepthImage, nullptr); g_vkDepthImage = VK_NULL_HANDLE; }
 	if (g_vkDepthImageMem)    { vkFreeMemory(g_vkDevice, g_vkDepthImageMem, nullptr); g_vkDepthImageMem = VK_NULL_HANDLE; }
 
-	if (g_vkVramStagingMap)   { vkUnmapMemory(g_vkDevice, g_vkVramStagingMem); g_vkVramStagingMap = nullptr; }
-	if (g_vkVramStaging)      { vkDestroyBuffer(g_vkDevice, g_vkVramStaging, nullptr); g_vkVramStaging = VK_NULL_HANDLE; }
-	if (g_vkVramStagingMem)   { vkFreeMemory(g_vkDevice, g_vkVramStagingMem, nullptr); g_vkVramStagingMem = VK_NULL_HANDLE; }
+	for (int i = 0; i < kMaxFramesInFlight; ++i) {
+		if (g_vkVramStagingMap[i]) { vkUnmapMemory(g_vkDevice, g_vkVramStagingMem[i]); g_vkVramStagingMap[i] = nullptr; }
+		if (g_vkVramStaging[i])    { vkDestroyBuffer(g_vkDevice, g_vkVramStaging[i], nullptr); g_vkVramStaging[i] = VK_NULL_HANDLE; }
+		if (g_vkVramStagingMem[i]) { vkFreeMemory(g_vkDevice, g_vkVramStagingMem[i], nullptr); g_vkVramStagingMem[i] = VK_NULL_HANDLE; }
+	}
 	if (g_vkVramSampler)      { vkDestroySampler(g_vkDevice, g_vkVramSampler, nullptr); g_vkVramSampler = VK_NULL_HANDLE; }
 	if (g_vkVramImageView)    { vkDestroyImageView(g_vkDevice, g_vkVramImageView, nullptr); g_vkVramImageView = VK_NULL_HANDLE; }
 	if (g_vkVramImage)        { vkDestroyImage(g_vkDevice, g_vkVramImage, nullptr); g_vkVramImage = VK_NULL_HANDLE; }
@@ -1328,8 +1677,10 @@ void GR_Shutdown()
 	if (g_vkDescPool)         { vkDestroyDescriptorPool(g_vkDevice, g_vkDescPool, nullptr); g_vkDescPool = VK_NULL_HANDLE; }
 	if (g_vkDescSetLayout)    { vkDestroyDescriptorSetLayout(g_vkDevice, g_vkDescSetLayout, nullptr); g_vkDescSetLayout = VK_NULL_HANDLE; }
 
-	for (int i = 0; i < 5; ++i) {
-		if (g_vkPipelines[i]) { vkDestroyPipeline(g_vkDevice, g_vkPipelines[i], nullptr); g_vkPipelines[i] = VK_NULL_HANDLE; }
+	for (int depthMode = 0; depthMode < kVkDepthModeCount; ++depthMode) {
+		for (int i = 0; i < kVkBlendModeCount; ++i) {
+			if (g_vkPipelines[depthMode][i]) { vkDestroyPipeline(g_vkDevice, g_vkPipelines[depthMode][i], nullptr); g_vkPipelines[depthMode][i] = VK_NULL_HANDLE; }
+		}
 	}
 	if (g_vkPipelineLayout)   { vkDestroyPipelineLayout(g_vkDevice, g_vkPipelineLayout, nullptr); g_vkPipelineLayout = VK_NULL_HANDLE; }
 	if (g_vkVertModule)       { vkDestroyShaderModule(g_vkDevice, g_vkVertModule, nullptr); g_vkVertModule = VK_NULL_HANDLE; }
@@ -1365,6 +1716,9 @@ void GR_BeginScene()
 {
 	if (g_vkSceneRecording) return;
 
+	g_vkDiagFrame++;
+	VkDiagResetFrame();
+
 	vkWaitForFences(g_vkDevice, 1, &g_vkInFlightFences[g_vkCurrentFrame], VK_TRUE, UINT64_MAX);
 
 	VkResult ar = vkAcquireNextImageKHR(g_vkDevice, g_vkSwapchain, UINT64_MAX,
@@ -1391,7 +1745,7 @@ void GR_BeginScene()
 	// are not allowed inside one.
 	if (g_vkVramDirty) {
 		// Refresh the staging buffer from the CPU mirror.
-		memcpy(g_vkVramStagingMap, g_vkVramCPU, sizeof(g_vkVramCPU));
+		memcpy(g_vkVramStagingMap[g_vkCurrentFrame], g_vkVramCPU, sizeof(g_vkVramCPU));
 
 		// SHADER_READ_ONLY → TRANSFER_DST → copy → SHADER_READ_ONLY
 		VramImageBarrier(cb,
@@ -1403,7 +1757,7 @@ void GR_BeginScene()
 		r.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 		r.imageSubresource.layerCount = 1;
 		r.imageExtent = { VRAM_WIDTH, VRAM_HEIGHT, 1 };
-		vkCmdCopyBufferToImage(cb, g_vkVramStaging, g_vkVramImage,
+		vkCmdCopyBufferToImage(cb, g_vkVramStaging[g_vkCurrentFrame], g_vkVramImage,
 			VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &r);
 
 		VramImageBarrier(cb,
@@ -1428,11 +1782,10 @@ void GR_BeginScene()
 	rpb.pClearValues = cv;
 	vkCmdBeginRenderPass(cb, &rpb, VK_SUBPASS_CONTENTS_INLINE);
 
-	// Default viewport + scissor cover the whole swapchain. The Y axis is
-	// flipped (negative height) so vertices coming out of GR_Ortho2D /
-	// GR_Perspective3D — which are written for the GL backend's clip
-	// space (Y-up) — still rasterise the right way up under Vulkan's
-	// Y-down clip space. Requires VK_KHR_maintenance1, in core since 1.1.
+	// Y-flip via negative-height viewport (VK_KHR_maintenance1 / VK 1.1
+	// core). The 2D ortho matrix and the 3D shader's `* vec2(1, -1)`
+	// both produce GL-style Y-up clip space; this viewport flip brings
+	// it back to VK's Y-down screen.
 	VkViewport vp = {};
 	vp.x = 0.0f;
 	vp.y = (float)g_vkSwapchainExtent.height;
@@ -1447,10 +1800,11 @@ void GR_BeginScene()
 	// Bind initial blend-mode pipeline + vertex buffer + descriptor set.
 	// GR_DrawTriangles will rebind a different pipeline if the engine
 	// switches blend modes mid-frame.
-	g_vkBoundPipelineIdx = BM_NONE;
-	vkCmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, g_vkPipelines[BM_NONE]);
+		g_vkBoundPipelineKey = GetPipelineKey(kVkDepthEnabled, BM_NONE);
+		vkCmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, g_vkPipelines[kVkDepthEnabled][BM_NONE]);
 	VkDeviceSize zero = 0;
-	vkCmdBindVertexBuffers(cb, 0, 1, &g_vkVertexBuffer, &zero);
+	VkBuffer vertexBuffer = g_vkVertexBuffer[g_vkCurrentFrame];
+	vkCmdBindVertexBuffers(cb, 0, 1, &vertexBuffer, &zero);
 	vkCmdBindDescriptorSets(cb, VK_PIPELINE_BIND_POINT_GRAPHICS,
 		g_vkPipelineLayout, 0, 1, &g_vkDescSet, 0, nullptr);
 
@@ -1466,8 +1820,42 @@ void GR_EndScene()
 {
 	if (!g_vkSceneRecording) return;
 
+	VkDiagLogFrame();
+
 	VkCommandBuffer cb = g_vkCmdBuffers[g_vkCurrentFrame];
 	vkCmdEndRenderPass(cb);
+
+	const VkDeviceSize captureBytes = (VkDeviceSize)g_vkSwapchainExtent.width * g_vkSwapchainExtent.height * 4;
+	VkBuffer captureBuffer = VK_NULL_HANDLE;
+	VkDeviceMemory captureMemory = VK_NULL_HANDLE;
+	const bool captureThisFrame =
+		g_vkSwapchainCanReadback &&
+		VkCaptureFrame() >= 0 &&
+		(int)g_vkDiagFrame == VkCaptureFrame() &&
+		CreateBuffer(captureBytes,
+			VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+			&captureBuffer, &captureMemory);
+
+	if (captureThisFrame) {
+		SwapchainImageBarrier(cb,
+			VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+			VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT,
+			VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+
+		VkBufferImageCopy copy = {};
+		copy.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		copy.imageSubresource.layerCount = 1;
+		copy.imageExtent = { g_vkSwapchainExtent.width, g_vkSwapchainExtent.height, 1 };
+		vkCmdCopyImageToBuffer(cb, g_vkSwapchainImages[g_vkAcquiredImageIdx],
+			VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, captureBuffer, 1, &copy);
+
+		SwapchainImageBarrier(cb,
+			VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+			VK_ACCESS_TRANSFER_READ_BIT, 0,
+			VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+	}
+
 	vkEndCommandBuffer(cb);
 
 	VkPipelineStageFlags waitStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
@@ -1481,6 +1869,23 @@ void GR_EndScene()
 	si.signalSemaphoreCount = 1;
 	si.pSignalSemaphores = &g_vkRenderFinishedSems[g_vkCurrentFrame];
 	VK_CHECK(vkQueueSubmit(g_vkGraphicsQueue, 1, &si, g_vkInFlightFences[g_vkCurrentFrame]));
+
+	if (captureThisFrame) {
+		VK_CHECK(vkWaitForFences(g_vkDevice, 1, &g_vkInFlightFences[g_vkCurrentFrame], VK_TRUE, UINT64_MAX));
+		void* mapped = nullptr;
+		VK_CHECK(vkMapMemory(g_vkDevice, captureMemory, 0, captureBytes, 0, &mapped));
+		std::vector<unsigned char> pixels((size_t)captureBytes);
+		memcpy(pixels.data(), mapped, (size_t)captureBytes);
+		vkUnmapMemory(g_vkDevice, captureMemory);
+		ConvertSwapchainPixelsToBgra(pixels.data(), g_vkSwapchainExtent.width, g_vkSwapchainExtent.height);
+		const char* capturePath = VkCapturePath();
+		if (WriteBgraBmp(capturePath, pixels.data(), g_vkSwapchainExtent.width, g_vkSwapchainExtent.height))
+			eprintinfo("[VK] captured frame %llu to %s\n", (unsigned long long)g_vkDiagFrame, capturePath);
+		else
+			eprinterr("[VK] failed to capture frame %llu to %s\n", (unsigned long long)g_vkDiagFrame, capturePath);
+		vkDestroyBuffer(g_vkDevice, captureBuffer, nullptr);
+		vkFreeMemory(g_vkDevice, captureMemory, nullptr);
+	}
 
 	VkPresentInfoKHR pi = {};
 	pi.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
@@ -1523,16 +1928,14 @@ void GR_ClearVRAM(int, int, int, int, unsigned char, unsigned char, unsigned cha
 
 void GR_UpdateVertexBuffer(const GrVertex* vertices, int count)
 {
-	if (!vertices || count <= 0 || !g_vkVertexBufferMap) return;
+	void* vertexBufferMap = g_vkVertexBufferMap[g_vkCurrentFrame];
+	if (!vertices || count <= 0 || !vertexBufferMap) return;
 	if (count > MAX_VERTEX_BUFFER_SIZE) count = MAX_VERTEX_BUFFER_SIZE;
-	memcpy(g_vkVertexBufferMap, vertices, sizeof(GrVertex) * (size_t)count);
+	memcpy(vertexBufferMap, vertices, sizeof(GrVertex) * (size_t)count);
 	g_vkVertexBufferSize = (uint32_t)count;
 
-	// DEBUG: dump first 3 vertices once per ~120 frames — but only when
-	// the buffer has more than 30 vertices (skips the FMV's 6-vertex
-	// underlay quad so we get real engine geometry samples).
 	static int s_dumpTick = 0;
-	if (++s_dumpTick >= 120 && count >= 30) {
+	if (VkDrawLogEnabled() && ++s_dumpTick >= 120 && count >= 30) {
 		s_dumpTick = 0;
 		for (int i = 0; i < 3 && i < count; ++i) {
 			const GrVertex& v = vertices[i];
@@ -1570,23 +1973,30 @@ void GR_DrawTriangles(int start_vertex, int triangles)
 	s_trisSinceLog += (uint64_t)(triangles > 0 ? triangles : 0);
 
 	if (!g_vkSceneRecording || triangles <= 0) return;
+	if (g_PreviousOffscreenState) return;
+
 	VkCommandBuffer cb = g_vkCmdBuffers[g_vkCurrentFrame];
 
-	// Switch pipeline if blend mode changed since last draw.
-	if (g_vkActiveBlendMode != g_vkBoundPipelineIdx) {
-		const int idx = (g_vkActiveBlendMode >= 0 && g_vkActiveBlendMode < 5)
-			? g_vkActiveBlendMode : 0;
-		vkCmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, g_vkPipelines[idx]);
-		g_vkBoundPipelineIdx = idx;
+	const int blendIdx = (g_vkActiveBlendMode >= 0 && g_vkActiveBlendMode < kVkBlendModeCount)
+		? g_vkActiveBlendMode : 0;
+	const int depthIdx = (g_vkActiveDepthMode == kVkDepthEnabled && g_cfg_pgxpZBuffer)
+		? kVkDepthEnabled : kVkDepthDisabled;
+	const int pipelineKey = GetPipelineKey(depthIdx, blendIdx);
+
+	if (pipelineKey != g_vkBoundPipelineKey) {
+		vkCmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, g_vkPipelines[depthIdx][blendIdx]);
+		g_vkBoundPipelineKey = pipelineKey;
 	}
 
 	vkCmdPushConstants(cb, g_vkPipelineLayout,
 		VK_SHADER_STAGE_VERTEX_BIT,
 		0, sizeof(PushBlock), &g_vkPushBlock);
 
+	VkDiagAccumulateDraw(start_vertex, triangles);
+
 	vkCmdDraw(cb, (uint32_t)(triangles * 3), 1, (uint32_t)start_vertex, 0);
 
-	if (++s_logTickFrame >= 60) {
+	if (VkDrawLogEnabled() && ++s_logTickFrame >= 60) {
 		eprintinfo("[VK] draws/s=%llu tris/s=%llu vbufVerts=%u\n",
 			(unsigned long long)s_drawsSinceLog,
 			(unsigned long long)s_trisSinceLog,
@@ -1658,17 +2068,15 @@ void GR_CopyVRAM(unsigned short* src, int x, int y, int w, int h, int dst_x, int
 		src += stride;
 	}
 
-	// DEBUG: count uploads + sample one pixel so we can see if data flows.
 	static int s_uploads = 0;
 	static int s_logTick = 0;
 	s_uploads++;
-	if (++s_logTick >= 20) {
+	if (VkDrawLogEnabled() && ++s_logTick >= 20) {
 		s_logTick = 0;
-		// pick the centre of the just-copied region
 		int cx = dst_x + w/2;
 		int cy = dst_y + h/2;
 		unsigned short v = g_vkVramCPU[cy * VRAM_WIDTH + cx];
-		eprintinfo("[VK][VRAM] upload #%d → (%d,%d) %dx%d  centre[%d,%d]=0x%04x\n",
+		eprintinfo("[VK][VRAM] upload #%d -> (%d,%d) %dx%d center[%d,%d]=0x%04x\n",
 			s_uploads, dst_x, dst_y, w, h, cx, cy, (unsigned)v);
 	}
 }
@@ -1714,7 +2122,11 @@ void GR_SetBlendMode(BlendMode bm)
 }
 void GR_SetPolygonOffset(float) {}
 void GR_SetStencilMode(int v)    { g_PreviousStencilMode = v; }
-void GR_EnableDepth(int v)       { g_PreviousDepthMode = v; }
+void GR_EnableDepth(int v)
+{
+	g_PreviousDepthMode = v;
+	g_vkActiveDepthMode = (v && g_cfg_pgxpZBuffer) ? kVkDepthEnabled : kVkDepthDisabled;
+}
 // Engine state owned by PsyX_GPU.cpp — needed by GR_SetupClipMode to
 // translate the engine's PSX-space clip rect into a window-space scissor.
 extern "C" { extern DISPENV activeDispEnv; }


### PR DESCRIPTION
## Summary

Adds a Vulkan / MoltenVK rendering backend alongside the existing OpenGL one, and brings the GTE / PGXP layer up to LP64 / arm64 portability. Selected at premake time via `--renderer=vulkan`. The OpenGL backend is unchanged when the option is not passed.

Companion PR (outer repo, build system + game-side fixes): OpenDriver2/REDRIVER2#223

## Vulkan backend (`src/render/PsyX_render_vk.cpp`)

- Single render-pass design: clear color + depth on `loadOp=CLEAR`, all primitives recorded inside one `vkCmdBeginRenderPass` / `End` per frame.
- 10 pre-baked PSOs in a `[depthMode][blendMode]` matrix. Depth-disabled variants are bound when the engine calls `GR_EnableDepth(0)` (HUD, sky, FMV, particles); depth-enabled variants use `LESS_OR_EQUAL` to mirror `glDepthFunc(GL_LEQUAL)`. Depth write is on for `BM_NONE` only — every blended mode reads but does not write depth, same as the GL backend's per-blend `glDepthMask` toggling.
- Per-frame-in-flight vertex buffer and VRAM staging buffer. The previous single-buffer design had the CPU overwriting vertices the GPU was still reading.
- VRAM exposed as 1024×512 `R8G8_UNORM` (low byte → `.r`, high byte → `.g`, matches the GL backend's `GL_RG / GL_UNSIGNED_BYTE` upload). Sampler is `REPEAT` — the tpage→address math leaks bits 5+ (TP / ABR / dither) into the page-X coord; GL silently wraps via the default `GL_REPEAT`, so `CLAMP_TO_EDGE` here was making every TP=1 / ABR>0 primitive read row 511 (wheels, particles rendered as solid blocks).
- Y-flip via VK_KHR_maintenance1 negative-height viewport (no projection mangling).
- GL→VK NDC z remap in the vertex shader: `gl_Position.z = (gl_Position.z + gl_Position.w) * 0.5`.
- Vertex shader implements the full PGXP path: geometry offset 0.5, `vec2(1, -1)` Y-flip, perspective offset via `a_zw.zw * w`. The fragment shader is a straight port of the GL `GPU_FRAGMENT_SAMPLE_SHADER` with branched `samplePSX` for 4-bit / 8-bit / 16-bit, `packRG` / `decodeRG` arithmetic and `c_PackRange = 255.001`.
- Sub-texel UV bias (`vec2(0.00025)`) on the clut coords — same `c_UVFudge` the GL backend uses to keep `NEAREST` sampling from drifting one texel left and pulling palette index 0 (transparency mask) for 4-bit STP=1 sprites.
- `GR_DrawTriangles` early-returns when `activeDrawEnv.dfe = 0`. `dfe` (draw frame enable) means "draw in display area" — when 0 the engine intends to render to VRAM auxiliary memory, not to the swapchain. The previous backend ignored the flag and offscreen passes leaked onto the screen layered in an order that varied with split count.
- 5 blend modes pre-baked as separate `VkPipelineColorBlendAttachmentState`. PSX STP-bit handling: fragment outputs `alpha = 0.5` for STP=1 texels, the `BM_AVERAGE = (SRC_ALPHA, ONE_MINUS_SRC_ALPHA)` pipeline produces the 50/50 mix; STP=0 texels exit with `alpha = 1.0` and render opaque even inside a semi-trans primitive.

## PGXP cache by destination address (`src/gte/PsyX_GTE.cpp`, `include/psx/inline_c.h`)

The original PGXP cache hashes by `(sx | sy << 16)` — the projected screen coordinate. Two distinct world-space vertices that rasterise to the same screen pixel collide; in dense scenes the linear-probe fallback returned an unrelated entry and vertex positions jittered between frames as the camera rotated.

- New `PGXP_RecordAddressIndex` / `PGXP_GetAddressIndex` open-addressed hash table (256K slots) keyed on the destination pointer of a `gte_stsxy*` macro, mapping (vertex-output address) → cache index.
- `gte_stsxy / gte_stsxy0/1/2/3` macros now record the destination address alongside the existing `g_FP_SXYZ*.x` write.
- `PGXP_GetCacheDataExact` does a direct read by index when the address is known. `ApplyVertexPGXP` tries the address-keyed path first and only falls back to the screen-coord lookup if the address table misses.
- `PGXP_ClearCache` memsets the cache to `0xFF` (lookup = `0xFFFFFFFF`, never matches a real `(sx, sy)`) so stale entries from previous frames don't poison the linear-probe fallback.

## NCLIP simplification

`gte_nclip` previously had two paths gated by `g_cfg_pgxpTextureCorrection`. The PGXP path computed a 3D plane normal via `normalize(cross(v2-v1, v0-v1))` and returned `±1` based on `dot(v0, normal)`. For triangles edge-on to the camera, `normal.z ≈ 0`; `normalize()` divided by ~0 and amplified fp32 noise to ±epsilon, so the sign flipped frame-to-frame as the camera rotated → triangles toggled between drawn and culled. Replaced with the 2D screen-space cross-product on both paths (matches the real GTE).

## Vertex emit (`src/gpu/PsyX_GPU.cpp`)

- `ApplyVertexPGXP` split into `FindVertexPGXP` (lookup, fills `PGXPVData`) + `ApplyVertexPGXP` (writes `GrVertex`). `MakeVertexTriangle` / `MakeVertexQuad` now require **all** vertices of a primitive to have valid PGXP data before applying — partial PGXP would leave a triangle with mixed perspective + 2D vertices and produce a degenerate shape.
- `PrimitivePGXPValid` rejects primitives where any vertex has `pz <= 0.25` (behind near plane) or `scr_h <= 100` (didn't go through the 3D path); rejected prims fall back to integer screen coords.
- Splits gain a `depthEnable` field and `SetCurrentSplitDepth` so the engine's `GR_EnableDepth` toggling is reflected in the split list.

## Build system

- `premake5_psycross.lua` adds the `--renderer={opengl|vulkan}` switch (default `opengl`) gated by an `os.target() == "macosx"` filter, swaps `PsyX_render.cpp` ↔ `PsyX_render_vk.cpp` via `removefiles`, and adds Homebrew prefix detection for arm64 (`/opt/homebrew`) and Intel (`/usr/local`). Includes Vulkan headers / loader, MoltenVK, and `shaderc` for runtime GLSL→SPIR-V compilation (statically linked from `libshaderc_combined.a`).

## LP64 / portability

- `include/psx/libgpu.h` — `P_LEN = 3` on `__aarch64__` (matches `_M_X64`) so the prim-tag struct is 12 bytes on every 64-bit target.
- `include/psx/types.h` — on LP64 macOS / Linux x64, `u_long` and `ulong` map to `uint32_t` so PSX 32-bit semantics are preserved. Pre-defines `_U_LONG` / `_U_INT` / `_U_CHAR` / `_U_SHORT` on macOS to stop `<sys/types.h>` from re-declaring those types as 64-bit.
- `src/psx/LIBCD.C`, `src/psx/LIBETC.C`, `src/psx/LIBGPU.C`, `src/psx/LIBSPU.C` — `malloc.h` / `__unix__` guards extended for macOS, plus a couple of pointer-cast tightening fixes the LP64 build flagged.

## Diagnostic plumbing

Env vars (read once, cached):

- `REDRIVER2_VK_DIAG=1` enables `[VKDIAG]` and `[PGXPDIAG]` per-frame logging.
- `REDRIVER2_VK_DIAG_INTERVAL=N` — log every N frames (default 60).
- `REDRIVER2_VK_DRAW_LOG=1` — verbose `GR_DrawTriangles` / `GR_CopyVRAM` / `GR_UpdateVertexBuffer` logs.
- `REDRIVER2_VK_CAPTURE_FRAME=N` + `REDRIVER2_VK_CAPTURE_PATH=path.bmp` — copy the swapchain image at frame N to a 32-bit BGRA BMP for diff-based debugging.

`[VKDIAG]` reports draws / triangles, depth on/off split, PGXP vs flat triangle ratio, clip rejects (L/R/T/B/N/F), `w <= 0` counts, ranges of `clipW` / `clipZ` / `ndcZ`. `[PGXPDIAG]` reports emit / get / direct-hit / fallback-hit counts, fallback-delta histogram in [-8..8], NCLIP +/0/− split, RTPS `pz` range, address-table hit/miss.

## Known gaps

- Stencil mode is recorded but Vulkan PSOs don't yet have stencil setup. Reflections / shadows that rely on stencil masking in the GL backend render without it.
- `GR_SetPolygonOffset` is a no-op. Not currently exercised in the playable path.
- `GR_ClearVRAM` is a stub; the engine's CPU-side mirror (`g_vkVramCPU`) is kept in sync via `GR_CopyVRAM`.
- Sky polygons take the 2D path (PGXP index forced to `0xffff`); they previously fed stale cache entries via `pgxp_index = PGXP_GetIndex(0) - 1`.
- BMP capture only handles `B8G8R8A8` and `R8G8B8A8` (unorm and sRGB) swapchain formats.

## Test plan

- [ ] Builds clean on macOS arm64 with both renderers.
- [ ] Driver 2 main menu, HUD and 3D world render under Vulkan/MoltenVK.
- [ ] OpenGL backend on Windows / Linux is unchanged.
- [ ] No new compiler warnings on existing 64-bit Windows / Linux x64 builds.